### PR TITLE
Modernize `and_predicate`

### DIFF
--- a/test/x3/and_predicate.cpp
+++ b/test/x3/and_predicate.cpp
@@ -1,16 +1,17 @@
 /*=============================================================================
     Copyright (c) 2001-2015 Joel de Guzman
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
+#include "test.hpp"
+
 #include <boost/spirit/home/x3.hpp>
 
 #include <iostream>
-#include "test.hpp"
 
-int
-main()
+int main()
 {
     using spirit_test::test;
     using boost::spirit::x3::int_;


### PR DESCRIPTION
Part of #4 

Use concepts in `and_predicate`, aka `operator&`.