### PR TITLE
Modernize miscellaneous components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x ./llvm.sh
           sudo ./llvm.sh ${{ matrix.compiler.version }}
-          sudo apt-get install -y libc++-${{ matrix.compiler.version }}-dev libc++abi-${{ matrix.compiler.version }}-dev
+          sudo apt-get install -y libc++-${{ matrix.compiler.version }}-dev libc++abi-${{ matrix.compiler.version }}-dev libunwind-${{ matrix.compiler.version }}-dev
           echo "BOOST_SPIRIT_STDLIB=stdlib=libc++" >> "$GITHUB_ENV"
 
       - name: Fetch Environment Info

--- a/include/boost/spirit/home/x3/operator/not_predicate.hpp
+++ b/include/boost/spirit/home/x3/operator/not_predicate.hpp
@@ -1,47 +1,61 @@
 /*=============================================================================
     Copyright (c) 2001-2014 Joel de Guzman
     Copyright (c) 2017 wanghan02
-    Copyright (c) 2024 Nana Sakisaka
+    Copyright (c) 2024-2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
-#if !defined(BOOST_SPIRIT_X3_NOT_PREDICATE_MARCH_23_2007_0618PM)
+#ifndef BOOST_SPIRIT_X3_NOT_PREDICATE_MARCH_23_2007_0618PM
 #define BOOST_SPIRIT_X3_NOT_PREDICATE_MARCH_23_2007_0618PM
 
 #include <boost/spirit/home/x3/core/parser.hpp>
 #include <boost/spirit/home/x3/support/expectation.hpp>
 
-namespace boost { namespace spirit { namespace x3
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x3
 {
     template <typename Subject>
     struct not_predicate : unary_parser<Subject, not_predicate<Subject>>
     {
-        typedef unary_parser<Subject, not_predicate<Subject>> base_type;
+        using base_type = unary_parser<Subject, not_predicate<Subject>>;
+        using attribute_type = unused_type;
 
-        typedef unused_type attribute_type;
-        static bool const has_attribute = false;
+        static constexpr bool has_attribute = false;
 
-        constexpr not_predicate(Subject const& subject)
-          : base_type(subject) {}
+        template <typename SubjectT>
+            requires
+                (!std::is_same_v<std::remove_cvref_t<SubjectT>, not_predicate>) &&
+                std::is_constructible_v<base_type, SubjectT>
+        constexpr not_predicate(SubjectT&& subject)
+            noexcept(std::is_nothrow_constructible_v<base_type, SubjectT>)
+            : base_type(std::forward<SubjectT>(subject))
+        {}
 
-        template <typename Iterator, typename Context
-          , typename RContext, typename Attribute>
-        bool parse(Iterator& first, Iterator const& last
-          , Context const& context, RContext& rcontext, Attribute& /*attr*/) const
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        [[nodiscard]] constexpr bool
+        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& /*attr*/) const
+            noexcept(
+                std::is_nothrow_copy_assignable_v<It> &&
+                is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type>
+            )
         {
-            Iterator i = first;
-            return !this->subject.parse(i, last, context, rcontext, unused)
-              && !has_expectation_failure(context);
+            It local_first = first;
+            return !this->subject.parse(local_first, last, context, rcontext, unused)
+                && !has_expectation_failure(context);
         }
     };
 
-    template <typename Subject>
-    constexpr not_predicate<typename extension::as_parser<Subject>::value_type>
-    operator!(Subject const& subject)
+    template <X3Subject Subject>
+    [[nodiscard]] constexpr not_predicate<as_parser_plain_t<Subject>>
+    operator!(Subject&& subject)
+        noexcept(is_parser_nothrow_constructible_v<not_predicate<as_parser_plain_t<Subject>>, Subject>)
     {
-        return { as_parser(subject) };
+        return { as_parser(std::forward<Subject>(subject)) };
     }
-}}}
+} // boost::spirit::x3
 
 #endif

--- a/include/boost/spirit/home/x3/support/context.hpp
+++ b/include/boost/spirit/home/x3/support/context.hpp
@@ -1,31 +1,51 @@
 /*=============================================================================
     Copyright (c) 2001-2014 Joel de Guzman
-    http://spirit.sourceforge.net/
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
-#if !defined(BOOST_SPIRIT_X3_CONTEXT_JAN_4_2012_1215PM)
+#ifndef BOOST_SPIRIT_X3_CONTEXT_JAN_4_2012_1215PM
 #define BOOST_SPIRIT_X3_CONTEXT_JAN_4_2012_1215PM
 
 #include <boost/spirit/home/x3/support/unused.hpp>
-#include <boost/mpl/identity.hpp>
 
-namespace boost { namespace spirit { namespace x3
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x3
 {
+    // For backward compatibility, we can't introduce a new
+    // vocabulary type because many codebase does partial
+    // specialization on `x3::context`. Instead, provide
+    // yet another layer of partial specialization to
+    // provide owning context.
+    template <typename T>
+    struct owning_context_tag {};
+
     template <typename ID, typename T, typename Next = unused_type>
     struct context
     {
-        context(T& val, Next const& next)
-            : val(val), next(next) {}
+        static_assert(!std::is_reference_v<T>);
+        static_assert(!std::is_reference_v<Next>);
+        static_assert(!std::is_const_v<Next>);
 
-        T& get(mpl::identity<ID>) const
+        constexpr context(T& val, Next const& next) noexcept
+            : val(val)
+            , next(next)
+        {}
+
+        context(T&, Next const&&) = delete; // dangling
+        context(std::remove_cvref_t<T> const&&, Next const&) = delete; // dangling
+        context(std::remove_cvref_t<T> const&&, Next const&&) = delete; // dangling
+
+        [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept
         {
             return val;
         }
 
         template <typename ID_>
-        decltype(auto) get(ID_ id) const
+        [[nodiscard]] constexpr decltype(auto) get(ID_ id) const noexcept
         {
             return next.get(id);
         }
@@ -34,22 +54,50 @@ namespace boost { namespace spirit { namespace x3
         Next const& next;
     };
 
-    template <typename ID, typename T>
-    struct context<ID, T, unused_type>
+    template <typename ID, typename T, typename Next>
+    struct context<ID, T, owning_context_tag<Next>>
     {
-        context(T& val)
-            : val(val) {}
+        static_assert(!std::is_reference_v<Next>);
 
-        context(T& val, unused_type)
-            : val(val) {}
+        template <typename OwningNext>
+            requires std::is_constructible_v<Next, OwningNext>
+        constexpr context(T& val, OwningNext&& owning_next)
+            noexcept(std::is_nothrow_constructible_v<Next, OwningNext>)
+            : val(val)
+            , next(std::forward<OwningNext>(owning_next))
+        {}
 
-        T& get(mpl::identity<ID>) const
+        [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept
         {
             return val;
         }
 
         template <typename ID_>
-        unused_type get(ID_) const
+        [[nodiscard]] constexpr decltype(auto) get(ID_ id) const noexcept
+        {
+            return next.get(id);
+        }
+
+        T& val;
+        Next next; // not reference
+    };
+
+    template <typename ID, typename T>
+    struct context<ID, T, unused_type>
+    {
+        constexpr context(T& val) noexcept
+            : val(val) {}
+
+        constexpr context(T& val, unused_type) noexcept
+            : val(val) {}
+
+        [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept
+        {
+            return val;
+        }
+
+        template <typename ID_>
+        [[nodiscard]] constexpr unused_type get(ID_) const noexcept
         {
             return unused_type{};
         }
@@ -58,19 +106,19 @@ namespace boost { namespace spirit { namespace x3
     };
 
     template <typename Tag, typename Context>
-    inline decltype(auto) get(Context const& context)
+    [[nodiscard]] constexpr decltype(auto) get(Context const& context) noexcept
     {
-        return context.get(mpl::identity<Tag>());
+        return context.get(std::type_identity<Tag>{});
     }
 
     template <typename ID, typename T, typename Next>
-    inline context<ID, T, Next> make_context(T& val, Next const& next)
+    [[nodiscard]] constexpr context<ID, T, Next> make_context(T& val, Next const& next) noexcept
     {
         return { val, next };
     }
 
     template <typename ID, typename T>
-    inline context<ID, T> make_context(T& val)
+    [[nodiscard]] constexpr context<ID, T> make_context(T& val) noexcept
     {
         return { val };
     }
@@ -78,26 +126,88 @@ namespace boost { namespace spirit { namespace x3
     namespace detail
     {
         template <typename ID, typename T, typename Next, typename FoundVal>
-        inline Next const&
-        make_unique_context(T& /* val */, Next const& next, FoundVal&)
+        [[nodiscard]] constexpr Next const&
+        make_unique_context(T& /* val */, Next const& next, FoundVal&) noexcept
         {
             return next;
         }
 
         template <typename ID, typename T, typename Next>
-        inline context<ID, T, Next>
-        make_unique_context(T& val, Next const& next, unused_type)
+        [[nodiscard]] constexpr context<ID, T, Next>
+        make_unique_context(T& val, Next const& next, unused_type) noexcept
         {
             return { val, next };
         }
-    }
+    } // detail
 
     template <typename ID, typename T, typename Next>
-    inline auto
-    make_unique_context(T& val, Next const& next)
+    [[nodiscard]] constexpr auto
+    make_unique_context(T& val, Next const& next) noexcept
     {
         return detail::make_unique_context<ID>(val, next, x3::get<ID>(next));
     }
-}}}
+
+    // Replaces the contained reference of the leftmost context
+    // having the id `ID_To_Replace`. If no such context exists,
+    // append a new one.
+    //
+    // This helper makes it possible to dynamically update the
+    // reference bound to the (runtime) context, while avoiding
+    // infinite instantiation in recursive grammars.
+    //
+    // The most notable example of a parser that requires this
+    // operation is `x3::locals`. Without this helper, it would
+    // inevitably trigger infinite instantiation when binding
+    // a local variable instance to the context.
+    template <typename ID_To_Replace, typename ID, typename T, typename Next, typename NewVal>
+    [[nodiscard]] constexpr auto replace_context(
+        context<ID, T, Next> const& ctx, NewVal& new_val) noexcept
+    {
+        if constexpr (std::is_same_v<ID, ID_To_Replace>)
+        {
+            if constexpr (std::is_same_v<Next, unused_type>)
+            {
+                // Existing context found; replace it and end the search.
+                return context<ID, T, Next>{ new_val };
+            }
+            else
+            {
+                // Existing context found; replace it and end the search.
+                //
+                // The current implementation does not replace
+                // succeeding items, even when there exists
+                // duplicate contexts that share the same `ID`.
+                // We currently choose this strategy for the sake
+                // of compilation speed, and we are not aware of
+                // a practical use case of redundant contexts in
+                // general.
+                return context<ID, T, Next>{ new_val, ctx.next };
+            }
+        }
+        else // No match
+        {
+            if constexpr (std::is_same_v<Next, unused_type>)
+            {
+                // No match at all. Append a new one and return.
+                // Since we're doing the search from left to right,
+                // this branch means there was no existing context
+                // for `ID_To_Replace`.
+                using NewContext = context<ID_To_Replace, NewVal>;
+                return context<ID, T, owning_context_tag<NewContext>>{
+                    ctx.val, NewContext{ new_val }
+                };
+            }
+            else
+            {
+                // No match. Continue the replacement recursively.
+                using NewNext = decltype(x3::replace_context<ID_To_Replace>(ctx.next, new_val));
+                return context<ID, T, owning_context_tag<NewNext>>{
+                    ctx.val, x3::replace_context<ID_To_Replace>(ctx.next, new_val)
+                };
+            }
+        }
+    }
+
+} // boost::spirit::x3
 
 #endif

--- a/test/x3/any_parser.cpp
+++ b/test/x3/any_parser.cpp
@@ -1,20 +1,21 @@
 /*=============================================================================
     Copyright (c) 2001-2015 Joel de Guzman
     Copyright (c) 2013-2014 Agustin Berge
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ==============================================================================*/
+
+#include "test.hpp"
 
 #include <boost/spirit/home/x3.hpp>
 
 #include <string>
 #include <cstring>
 #include <iostream>
-#include "test.hpp"
 
-int
-main()
+int main()
 {
     using spirit_test::test_attr;
     using spirit_test::test;
@@ -29,8 +30,8 @@ main()
     using boost::spirit::x3::skipper_tag;
     using boost::spirit::x3::_attr;
 
-    typedef char const* iterator_type;
-    typedef decltype(make_context<skipper_tag>(space)) context_type;
+    using iterator_type = char const*;
+    using context_type = decltype(make_context<skipper_tag>(space));
     { // basic tests
 
         auto a = lit('a');

--- a/test/x3/rule1.cpp
+++ b/test/x3/rule1.cpp
@@ -1,31 +1,32 @@
 /*=============================================================================
     Copyright (c) 2001-2015 Joel de Guzman
+    Copyright (c) 2025 Nana Sakisaka
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
+
+#include "test.hpp"
 
 #include <boost/spirit/home/x3.hpp>
 
 #include <string>
 #include <cstring>
 #include <iostream>
-#include "test.hpp"
 
-int
-main()
+int main()
 {
     using spirit_test::test_attr;
     using spirit_test::test;
 
-    using namespace boost::spirit::x3::ascii;
+    using namespace boost::spirit::x3::standard;
     using boost::spirit::x3::rule;
     using boost::spirit::x3::lit;
     using boost::spirit::x3::int_;
     using boost::spirit::x3::unused_type;
     using boost::spirit::x3::phrase_parse;
     using boost::spirit::x3::skip_flag;
-    using boost::spirit::x3::traits::has_attribute;
+    using boost::spirit::x3::traits::has_attribute_v;
 
 #ifdef BOOST_SPIRIT_X3_NO_RTTI
     BOOST_SPIRIT_ASSERT_CONSTEXPR_CTORS(rule<class r>{});
@@ -34,11 +35,10 @@ main()
     BOOST_SPIRIT_ASSERT_CONSTEXPR_CTORS(rule<class r>{"r"} = 'x');
 
     // check attribute advertising
-    static_assert( has_attribute<rule<class r, int>, /*Context=*/unused_type>::value, "");
-    static_assert(!has_attribute<rule<class r     >, /*Context=*/unused_type>::value, "");
-    static_assert( has_attribute<decltype(rule<class r, int>{} = int_), /*Context=*/unused_type>::value, "");
-    static_assert(!has_attribute<decltype(rule<class r     >{} = int_), /*Context=*/unused_type>::value, "");
-
+    static_assert( has_attribute_v<rule<class r, int>, /*Context=*/unused_type>);
+    static_assert(!has_attribute_v<rule<class r     >, /*Context=*/unused_type>);
+    static_assert( has_attribute_v<decltype(rule<class r, int>{} = int_), /*Context=*/unused_type>);
+    static_assert(!has_attribute_v<decltype(rule<class r     >{} = int_), /*Context=*/unused_type>);
 
     { // basic tests
 


### PR DESCRIPTION
Part of #4 

This PR modernizes the miscellaneous components, which are the very remaining parts of the initial modernization attempt.

- Modernize `not_predicate` aka `operator!`
- Modernize `context`
- Add `replace_context`
  - This can be used to overwrite the existing context while avoiding infinite recursive instantiation. Required for implementing `x4::locals` and #11.
- Modernize `expectation_failure`. Includes the to-dos from boostorg/spirit#788. Finally.
- Modernize some tests. Only trivial changes.