### PR TITLE
Remove `RContext`

### DIFF
--- a/include/boost/spirit/config.hpp
+++ b/include/boost/spirit/config.hpp
@@ -10,6 +10,13 @@
 
 #include <version>
 
+#define BOOST_SPIRIT_STRINGIZE_I(x) #x
+#define BOOST_SPIRIT_STRINGIZE(x) BOOST_SPIRIT_STRINGIZE_I(x)
+
+#define BOOST_SPIRIT_CONCAT_I_I(a, b) a##b
+#define BOOST_SPIRIT_CONCAT_I(a, b) BOOST_SPIRIT_CONCAT_I_I(a, b)
+#define BOOST_SPIRIT_CONCAT(a, b) BOOST_SPIRIT_CONCAT_I(a, b)
+
 #if _MSC_VER
 # include <CodeAnalysis/CppCoreCheck/warnings.h>
 # pragma warning(default: CPPCORECHECK_LIFETIME_WARNINGS)

--- a/include/boost/spirit/core/type_traits.hpp
+++ b/include/boost/spirit/core/type_traits.hpp
@@ -1,0 +1,38 @@
+#ifndef BOOST_SPIRIT_CORE_TYPE_TRAITS_HPP
+#define BOOST_SPIRIT_CORE_TYPE_TRAITS_HPP
+
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include <boost/spirit/config.hpp>
+
+#include <type_traits>
+
+namespace boost::spirit {
+
+template<class T, template<class...> class TT>
+struct is_ttp_specialization_of : std::false_type {};
+
+template<template<class...> class TT, class... Ts>
+struct is_ttp_specialization_of<TT<Ts...>, TT> : std::true_type {};
+
+template<class T, template<class...> class TT>
+inline constexpr bool is_ttp_specialization_of_v = is_ttp_specialization_of<T, TT>::value;
+
+
+template<class T, template<auto...> class TT>
+struct is_nttp_specialization_of : std::false_type {};
+
+template<template<auto...> class TT, auto... Ts>
+struct is_nttp_specialization_of<TT<Ts...>, TT> : std::true_type {};
+
+template<class T, template<auto...> class TT>
+inline constexpr bool is_nttp_specialization_of_v = is_nttp_specialization_of<T, TT>::value;
+
+} // boost::spirit
+
+#endif

--- a/include/boost/spirit/x4/auxiliary/attr.hpp
+++ b/include/boost/spirit/x4/auxiliary/attr.hpp
@@ -43,9 +43,9 @@ namespace boost::spirit::x4
             : value_(std::forward<U>(value))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It&, Se const&, Context const&, RContext const&, Attribute& attr_) const
+        parse(It&, Se const&, Context const&, Attribute& attr_) const
             noexcept(noexcept(x4::move_to(std::as_const(value_), attr_)))
         {
             // Always copy (need reuse in repetitive invocations)

--- a/include/boost/spirit/x4/auxiliary/eoi.hpp
+++ b/include/boost/spirit/x4/auxiliary/eoi.hpp
@@ -24,9 +24,9 @@ namespace boost::spirit::x4
 
         static constexpr bool has_attribute = false;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute&) const
+        parse(It& first, Se const& last, Context const& context, Attribute&) const
             noexcept(
                 noexcept(x4::skip_over(first, last, context)) &&
                 noexcept(first == last)

--- a/include/boost/spirit/x4/auxiliary/eol.hpp
+++ b/include/boost/spirit/x4/auxiliary/eol.hpp
@@ -24,9 +24,9 @@ namespace boost::spirit::x4
 
         static constexpr bool has_attribute = false;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute&) const
+        parse(It& first, Se const& last, Context const& context, Attribute&) const
             // TODO: noexcept
         {
             x4::skip_over(first, last, context);

--- a/include/boost/spirit/x4/binary.hpp
+++ b/include/boost/spirit/x4/binary.hpp
@@ -45,7 +45,7 @@ namespace boost::spirit::x4
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, unused_type, Attribute& attr_param) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr_param) const
             // TODO: noexcept
         {
             x4::skip_over(first, last, context);
@@ -77,9 +77,9 @@ namespace boost::spirit::x4
 
         static constexpr bool has_attribute = !std::is_same_v<unused_type, T>;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute& attr_param) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr_param) const
             // TODO: noexcept
         {
             x4::skip_over(first, last, context);

--- a/include/boost/spirit/x4/char/char_parser.hpp
+++ b/include/boost/spirit/x4/char/char_parser.hpp
@@ -20,9 +20,9 @@ namespace boost::spirit::x4
     template <typename Derived>
     struct char_parser : parser<Derived>
     {
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             // TODO: noexcept
         {
             x4::skip_over(first, last, context);

--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -15,7 +15,13 @@
 namespace boost::spirit::x4
 {
     struct parse_pass_context_tag; // _pass
-    struct rule_val_context_tag; // _val
+
+    // _val
+    struct rule_val_context_tag
+    {
+        static constexpr bool is_unique = true;
+    };
+
     struct where_context_tag; // _where
     struct attr_context_tag; // _attr
 

--- a/include/boost/spirit/x4/core/context.hpp
+++ b/include/boost/spirit/x4/core/context.hpp
@@ -51,7 +51,7 @@ namespace boost::spirit::x4
     // TODO: check whether auto-completion is available for this current implementation.
     // If not, we should implement a partially specialized metafunction instead.
     template <typename ID, typename Context>
-    using get_context_t = std::remove_cvref_t<decltype(x4::get<ID>(std::declval<Context const&>()))>;
+    using get_context_plain_t = std::remove_cvref_t<decltype(x4::get<ID>(std::declval<Context const&>()))>;
 
 
     template <typename Context, typename ID_To_Search>
@@ -85,7 +85,7 @@ namespace boost::spirit::x4
     struct has_context_of
     {
         static_assert(!std::is_reference_v<T>);
-        static constexpr bool value = std::same_as<get_context_t<ID, Context>, T>;
+        static constexpr bool value = std::same_as<get_context_plain_t<ID, Context>, T>;
     };
 
     template <typename Context, typename ID, typename T>

--- a/include/boost/spirit/x4/core/context.hpp
+++ b/include/boost/spirit/x4/core/context.hpp
@@ -10,22 +10,108 @@
 =============================================================================*/
 
 #include <boost/spirit/config.hpp>
+#include <boost/spirit/core/type_traits.hpp>
+
 #include <boost/spirit/x4/core/unused.hpp>
 
+#include <concepts>
 #include <type_traits>
 #include <utility>
 
 namespace boost::spirit::x4
 {
-    template <typename T>
-    struct owning_context_tag {};
+    template <typename ID, typename T, typename Next>
+    struct context;
+
+    namespace detail
+    {
+        struct monostate_context_tag;
+        using monostate_context = context<monostate_context_tag, void, unused_type>;
+
+    } // detail
+
+    template <typename ContextT>
+    struct owning_context; // not defined
+
+    template <typename ID, typename T, typename Next>
+    struct owning_context<context<ID, T, Next>> {};
+
+
+    // TODO: Rename. `get` is too generic name.
+    template <typename ID, typename Context>
+    [[nodiscard]] constexpr decltype(auto)
+    get(Context const& context) noexcept
+    {
+        return context.get(std::type_identity<ID>{});
+    }
+
+    template <typename ID, typename Context>
+    void get(Context const&&) = delete; // dangling
+
+    // TODO: check whether auto-completion is available for this current implementation.
+    // If not, we should implement a partially specialized metafunction instead.
+    template <typename ID, typename Context>
+    using get_context_t = std::remove_cvref_t<decltype(x4::get<ID>(std::declval<Context const&>()))>;
+
+
+    template <typename Context, typename ID_To_Search>
+    struct has_context;
+
+    template <typename Context, typename ID_To_Search>
+    constexpr bool has_context_v = has_context<Context, ID_To_Search>::value;
+
+    template <typename ID_To_Search>
+    struct has_context<unused_type, ID_To_Search>
+        : std::false_type
+    {};
+
+    template <typename T, typename Next, typename ID_To_Search>
+    struct has_context<context<ID_To_Search, T, Next>, ID_To_Search>
+        : std::true_type
+    {};
+
+    template <typename ID, typename T, typename Next, typename ID_To_Search>
+        requires (!std::same_as<ID, ID_To_Search>)
+    struct has_context<context<ID, T, Next>, ID_To_Search>
+        : has_context<Next, ID_To_Search>
+    {};
+
+    template <typename ContextT, typename ID_To_Search>
+    struct has_context<owning_context<ContextT>, ID_To_Search>
+        : has_context<ContextT, ID_To_Search>
+    {};
+
+    template <typename Context, typename ID, typename T>
+    struct has_context_of
+    {
+        static_assert(!std::is_reference_v<T>);
+        static constexpr bool value = std::same_as<get_context_t<ID, Context>, T>;
+    };
+
+    template <typename Context, typename ID, typename T>
+    constexpr bool has_context_of_v = has_context_of<Context, ID, T>::value;
+
+
+    template <typename ID>
+    concept UniqueContextID = !requires { ID::is_unique; } || requires { requires ID::is_unique; };
+
+    namespace detail
+    {
+        template <typename ID, typename Next>
+        concept HasNoDuplicateContext = !UniqueContextID<ID> || !has_context_v<Next, ID>;
+
+    } // detail
 
     template <typename ID, typename T, typename Next = unused_type>
     struct context
     {
         static_assert(!std::is_reference_v<T>);
+        static_assert(!is_ttp_specialization_of_v<std::remove_const_t<T>, context>, "context's value type cannot be context");
+
         static_assert(!std::is_reference_v<Next>);
         static_assert(!std::is_const_v<Next>);
+        static_assert(detail::HasNoDuplicateContext<ID, Next>);
+        static_assert(!std::same_as<Next, detail::monostate_context>);
 
         constexpr context(T& val BOOST_SPIRIT_LIFETIMEBOUND, Next const& next BOOST_SPIRIT_LIFETIMEBOUND) noexcept
             : val(val)
@@ -35,6 +121,11 @@ namespace boost::spirit::x4
         context(T&, Next const&&) = delete; // dangling
         context(std::remove_const_t<T> const&&, Next const&) = delete; // dangling
         context(std::remove_const_t<T> const&&, Next const&&) = delete; // dangling
+
+        constexpr context(context&&) = default;
+        constexpr context& operator=(context&&) = default;
+        constexpr context(context const&) = delete;
+        constexpr context& operator=(context const&) = delete;
 
         [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
         {
@@ -50,37 +141,62 @@ namespace boost::spirit::x4
         Next const& next;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     };
 
+    // Empty context specialization. Materialized when `remove_context` removed everything.
+    template <>
+    struct context<detail::monostate_context_tag, void>
+    {
+        [[nodiscard]] static constexpr unused_type const& get(auto) noexcept
+        {
+            return unused;
+        }
+    };
+
     template <typename ID, typename T>
     struct context<ID, T, unused_type>
     {
-        constexpr context(T& val BOOST_SPIRIT_LIFETIMEBOUND) noexcept
-            requires (!std::is_same_v<std::remove_const_t<T>, context>)
+        static_assert(!std::is_reference_v<T>);
+        static_assert(!is_ttp_specialization_of_v<std::remove_const_t<T>, context>, "context's value type cannot be context");
+
+        constexpr explicit context(T& val BOOST_SPIRIT_LIFETIMEBOUND) noexcept
+            requires (!std::same_as<std::remove_const_t<T>, context>)
             : val(val)
         {}
-
-        context(std::remove_const_t<T> const&&) = delete; // dangling
 
         constexpr context(T& val BOOST_SPIRIT_LIFETIMEBOUND, unused_type) noexcept
             : val(val)
         {}
+
+        context(std::remove_const_t<T> const&&) = delete; // dangling
+        context(std::remove_const_t<T> const&&, unused_type) = delete; // dangling
+
+        constexpr context(context&&) = default;
+        constexpr context& operator=(context&&) = default;
+        constexpr context(context const&) = delete;
+        constexpr context& operator=(context const&) = delete;
 
         [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
         {
             return val;
         }
 
-        [[nodiscard]] static constexpr unused_type get(auto) noexcept
+        [[nodiscard]] static constexpr unused_type const& get(auto) noexcept
         {
-            return unused_type{};
+            return unused;
         }
 
         T& val;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
     };
 
     template <typename ID, typename T, typename Next>
-    struct context<ID, T, owning_context_tag<Next>>
+    struct context<ID, T, owning_context<Next>>
     {
+        static_assert(!std::is_reference_v<T>);
+        static_assert(!is_ttp_specialization_of_v<std::remove_const_t<T>, context>, "context's value type cannot be context");
+        static_assert(!std::same_as<std::remove_const_t<T>, unused_type>, "context holding `unused_type` as `T` is not supported");
+
         static_assert(!std::is_reference_v<Next>);
+        static_assert(detail::HasNoDuplicateContext<ID, Next>);
+        static_assert(!std::same_as<Next, detail::monostate_context>);
 
         template <typename OwningNext>
             requires std::is_constructible_v<Next, OwningNext>
@@ -93,6 +209,11 @@ namespace boost::spirit::x4
         template <typename OwningNext>
             requires std::is_constructible_v<Next, OwningNext>
         context(std::remove_const_t<T> const&&, OwningNext&&) = delete; // dangling
+
+        constexpr context(context&&) = default;
+        constexpr context& operator=(context&&) = default;
+        constexpr context(context const&) = delete;
+        constexpr context& operator=(context const&) = delete;
 
         [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
         {
@@ -108,21 +229,12 @@ namespace boost::spirit::x4
         Next next; // not reference
     };
 
-    template <typename ID, typename Context>
-    [[nodiscard]] constexpr decltype(auto)
-    get(Context const& context) noexcept
-    {
-        return context.get(std::type_identity<ID>{});
-    }
-
-    template <typename ID, typename Context>
-    void get(Context const&&) = delete; // dangling
 
     template <typename ID, typename T, typename Next>
     [[nodiscard]] constexpr context<ID, T, Next>
     make_context(T& val, Next const& next) noexcept
     {
-        return { val, next };
+        return {val, next};
     }
 
     template <typename ID, typename T, typename Next>
@@ -139,44 +251,11 @@ namespace boost::spirit::x4
     [[nodiscard]] constexpr context<ID, T>
     make_context(T& val) noexcept
     {
-        return { val };
+        return context<ID, T>{val};
     }
 
     template <typename ID, typename T>
     void make_context(T const&&) = delete; // dangling
-
-    namespace detail
-    {
-        template <typename ID, typename T, typename Next, typename FoundVal>
-        [[nodiscard]] constexpr Next const&
-        make_unique_context(T&, Next const& next BOOST_SPIRIT_LIFETIMEBOUND, FoundVal&) noexcept
-        {
-            return next;
-        }
-
-        template <typename ID, typename T, typename Next>
-        [[nodiscard]] constexpr context<ID, T, Next>
-        make_unique_context(T& val, Next const& next, unused_type) noexcept
-        {
-            return { val, next };
-        }
-    } // detail
-
-    template <typename ID, typename T, typename Next>
-    [[nodiscard]] constexpr auto
-    make_unique_context(T& val, Next const& next) noexcept
-    {
-        return detail::make_unique_context<ID>(val, next, x4::get<ID>(next));
-    }
-
-    template <typename ID, typename T, typename Next>
-    void make_unique_context(T const&&, Next const&) = delete; // dangling
-
-    template <typename ID, typename T, typename Next>
-    void make_unique_context(T const&&, Next const&&) = delete; // dangling
-
-    template <typename ID, typename T, typename Next>
-    void make_unique_context(T&, Next const&&) = delete; // dangling
 
 
     // Replaces the contained reference of the leftmost context
@@ -192,57 +271,156 @@ namespace boost::spirit::x4
     // inevitably trigger infinite instantiation when binding
     // a local variable instance to the context.
     template <typename ID_To_Replace, typename ID, typename T, typename Next, typename NewVal>
-    [[nodiscard]] constexpr auto replace_context(
-        context<ID, T, Next> const& ctx, NewVal& new_val BOOST_SPIRIT_LIFETIMEBOUND
+    [[nodiscard]] constexpr auto
+    replace_first_context(
+        context<ID, T, Next> const& ctx,
+        NewVal& new_val BOOST_SPIRIT_LIFETIMEBOUND
     ) noexcept
     {
-        if constexpr (std::is_same_v<ID, ID_To_Replace>)
+        static_assert(!is_ttp_specialization_of_v<std::remove_const_t<NewVal>, context>, "context's value type cannot be context");
+        static_assert(!std::same_as<ID_To_Replace, detail::monostate_context_tag>);
+
+        if constexpr (std::same_as<ID, ID_To_Replace>) // match
         {
-            if constexpr (std::is_same_v<Next, unused_type>)
+            if constexpr (std::same_as<Next, unused_type>)
             {
                 // Existing context found; replace it and end the search.
-                return context<ID, T, Next>{ new_val };
+                return context<ID, NewVal, Next>{new_val};
             }
             else
             {
                 // Existing context found; replace it and end the search.
                 //
-                // The current implementation does not replace
-                // succeeding items, even when there exists
-                // duplicate contexts that share the same `ID`.
-                // We currently choose this strategy for the sake
-                // of compilation speed, and we are not aware of
-                // a practical use case of redundant contexts in
-                // general.
-                return context<ID, T, Next>{ new_val, ctx.next };
+                // This implementation does not replace succeeding (duplicate) entries,
+                // because it is `replace_*first*_context`.
+                return context<ID, NewVal, Next>{new_val, ctx.next};
             }
         }
         else // No match
         {
-            if constexpr (std::is_same_v<Next, unused_type>)
+            if constexpr (std::same_as<ID, detail::monostate_context_tag>)
+            {
+                // No match at all. Create a brand-new context.
+                return context<ID_To_Replace, NewVal>{new_val};
+            }
+            else if constexpr (std::same_as<Next, unused_type>)
             {
                 // No match at all. Append a new one and return.
                 // Since we're doing the search from left to right,
                 // this branch means there was no existing context
                 // for `ID_To_Replace`.
                 using NewContext = context<ID_To_Replace, NewVal>;
-                return context<ID, T, owning_context_tag<NewContext>>{
-                    ctx.val, NewContext{ new_val }
+                return context<ID, T, owning_context<NewContext>>{
+                    ctx.val, NewContext{new_val}
                 };
             }
             else
             {
                 // No match. Continue the replacement recursively.
-                using NewNext = decltype(x4::replace_context<ID_To_Replace>(ctx.next, new_val));
-                return context<ID, T, owning_context_tag<NewNext>>{
-                    ctx.val, x4::replace_context<ID_To_Replace>(ctx.next, new_val)
+                using NewNext = decltype(x4::replace_first_context<ID_To_Replace>(ctx.next, new_val));
+                return context<ID, T, owning_context<NewNext>>{
+                    ctx.val, x4::replace_first_context<ID_To_Replace>(ctx.next, new_val)
                 };
             }
         }
     }
 
     template <typename ID_To_Replace, typename ID, typename T, typename Next, typename NewVal>
-    void replace_context(context<ID, T, Next> const&, NewVal const&&) = delete; // dangling
+    void replace_first_context(context<ID, T, Next> const&, NewVal const&&) = delete; // dangling
+
+    // Remove the contained reference of the leftmost context having the id `ID_To_Remove`.
+    template <typename ID_To_Remove, typename ID, typename T, typename Next>
+    [[nodiscard]] constexpr decltype(auto) // may return existing reference in some cases
+    remove_first_context(context<ID, T, Next> const& ctx) noexcept
+    {
+        static_assert(!std::same_as<ID_To_Remove, detail::monostate_context_tag>);
+
+        // It does not make sense to remove the "first" context of non-unique ID,
+        // because if you do so, you just can't determine the meaning of the remaining
+        // (duplicate) entries.
+        //
+        // For example, let the context have below structure:
+        //    context<
+        //      tag, int,
+        //      context<
+        //        tag, float,
+        //        context<
+        //          tag, double
+        //        >
+        //      >
+        //    >
+        //
+        // Applying `remove_first_context<tag>` results in this:
+        //    context<
+        //      tag, float,
+        //      context<
+        //        tag, double
+        //      >
+        //    >
+        //
+        // Although the operation is valid in type level, here's the question:
+        // what do you *mean* by the remaining `float` and `double` contexts?
+        //
+        // As you can see, a context may have arbitrary number of duplicate
+        // entries, and it just does not make sense to remove the "first" entry.
+        //
+        // For this reason, a "remove" operation on an any context is semantically
+        // valid if and only if the ID is unique. In such case, `remove_first_context`
+        // is essentially equal to `remove_*all*_context`, which is our intention.
+        static_assert(UniqueContextID<ID_To_Remove>);
+
+        if constexpr (std::same_as<ID, ID_To_Remove>) // match
+        {
+            if constexpr (std::same_as<Next, unused_type>)
+            {
+                // Existing context found; removing it will result in an
+                // empty context, so create a monostate placeholder.
+                return detail::monostate_context{};
+            }
+            else
+            {
+                // Existing context found; remove it and end the search.
+                return ctx.next;
+            }
+        }
+        else // No match
+        {
+            if constexpr (std::same_as<ID, detail::monostate_context_tag> || std::same_as<Next, unused_type>)
+            {
+                // No match at all. Return as-is.
+                return ctx;
+            }
+            else
+            {
+                // No match. Continue the replacement recursively.
+                using NewNext = decltype(x4::remove_first_context<ID_To_Remove>(ctx.next));
+
+                // If the recursive replacement resulted in a monostate context,
+                // prevent appending it; return the context without `next`.
+                if constexpr (std::same_as<NewNext, detail::monostate_context>)
+                {
+                    return context<ID, T>{ctx.val};
+                }
+                else if constexpr (std::is_reference_v<NewNext>)
+                {
+                    // Assert `decltype(auto)` is working as intended; i.e., no dangling reference
+                    static_assert(std::is_lvalue_reference_v<NewNext>);
+                    return context<ID, T, std::remove_cvref_t<NewNext>>{
+                        ctx.val, x4::remove_first_context<ID_To_Remove>(ctx.next)
+                    };
+                }
+                else // prvalue context
+                {
+                    return context<ID, T, owning_context<NewNext>>{
+                        ctx.val, x4::remove_first_context<ID_To_Remove>(ctx.next)
+                    };
+                }
+            }
+        }
+    }
+
+    template <typename ID_To_Remove, typename ID, typename T, typename Next>
+    void remove_first_context(context<ID, T, Next> const&&) = delete; // dangling
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/core/detail/parse_alternative.hpp
+++ b/include/boost/spirit/x4/core/detail/parse_alternative.hpp
@@ -159,41 +159,39 @@ namespace boost::spirit::x4::detail
     template <typename Parser, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
     constexpr bool is_reference_pseudo_type = std::is_reference_v<typename parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::type>;
 
-    template <typename Parser, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+    template <typename Parser, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         requires is_reference_pseudo_type<Parser, It, Se, Context, Attribute>
     [[nodiscard]] constexpr bool
     parse_alternative(
         Parser const& p, It& first, Se const& last,
-        Context const& context, RContext& rcontext, Attribute& attribute
+        Context const& context, Attribute& attribute
     ) noexcept(
         noexcept(parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::call(
             first, last, pass_variant_attribute<Parser, Attribute, Context>::call(attribute)
         )) &&
         is_nothrow_parsable_v<
-            Parser, It, Se, Context, RContext,
-            std::remove_reference_t<typename parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::type>
+            Parser, It, Se, Context, std::remove_reference_t<typename parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::type>
         >
     )
     {
         using pass = pass_variant_attribute<Parser, Attribute, Context>;
         using pseudo = traits::pseudo_attribute<Context, typename pass::type, It, Se>;
         typename pseudo::type attr_ = pseudo::call(first, last, pass::call(attribute));
-        return p.parse(first, last, context, rcontext, attr_);
+        return p.parse(first, last, context, attr_);
     }
 
-    template <typename Parser, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+    template <typename Parser, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         requires (!is_reference_pseudo_type<Parser, It, Se, Context, Attribute>)
     [[nodiscard]] constexpr bool
     parse_alternative(
         Parser const& p, It& first, Se const& last,
-        Context const& context, RContext& rcontext, Attribute& attribute
+        Context const& context, Attribute& attribute
     ) noexcept(
         noexcept(parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::call(
             first, last, pass_variant_attribute<Parser, Attribute, Context>::call(attribute)
         )) &&
         is_nothrow_parsable_v<
-            Parser, It, Se, Context, RContext,
-            std::remove_reference_t<typename parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::type>
+            Parser, It, Se, Context, std::remove_reference_t<typename parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::type>
         > &&
         noexcept(x4::move_to(
             std::declval<typename parse_alternative_pseudo_t<Parser, It, Se, Context, Attribute>::type&&>(),
@@ -205,7 +203,7 @@ namespace boost::spirit::x4::detail
         using pseudo = traits::pseudo_attribute<Context, typename pass::type, It, Se>;
         typename pseudo::type attr_ = pseudo::call(first, last, pass::call(attribute));
 
-        if (p.parse(first, last, context, rcontext, attr_))
+        if (p.parse(first, last, context, attr_))
         {
             x4::move_to(std::move(attr_), attribute);
             return true;
@@ -220,17 +218,17 @@ namespace boost::spirit::x4::detail
 
         using unary_parser<Subject, alternative_helper<Subject>>::unary_parser;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(noexcept(detail::parse_alternative(this->subject, first, last, context, rcontext, attr)))
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(noexcept(detail::parse_alternative(this->subject, first, last, context, attr)))
         {
-            return detail::parse_alternative(this->subject, first, last, context, rcontext, attr);
+            return detail::parse_alternative(this->subject, first, last, context, attr);
         }
     };
 
-    template <typename Left, typename Right, typename Context, typename RContext>
-    struct parse_into_container_impl<alternative<Left, Right>, Context, RContext>
+    template <typename Left, typename Right, typename Context>
+    struct parse_into_container_impl<alternative<Left, Right>, Context>
     {
         using parser_type = alternative<Left, Right>;
 
@@ -239,11 +237,11 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             parser_type const& parser,
-            It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attribute
+            It& first, Se const& last, Context const& context, Attribute& attribute
         )
         {
-            return detail::parse_into_container(alternative_helper<Left>{parser.left}, first, last, context, rcontext, attribute)
-                || detail::parse_into_container(alternative_helper<Right>{parser.right}, first, last, context, rcontext, attribute);
+            return detail::parse_into_container(alternative_helper<Left>{parser.left}, first, last, context, attribute)
+                || detail::parse_into_container(alternative_helper<Right>{parser.right}, first, last, context, attribute);
         }
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
@@ -252,11 +250,11 @@ namespace boost::spirit::x4::detail
         call(
             parser_type const& parser,
             It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attribute
+            Context const& context, Attribute& attribute
         )
         {
-            return detail::parse_into_container(parser.left, first, last, context, rcontext, attribute)
-                || detail::parse_into_container(parser.right, first, last, context, rcontext, attribute);
+            return detail::parse_into_container(parser.left, first, last, context, attribute)
+                || detail::parse_into_container(parser.right, first, last, context, attribute);
         }
     };
 

--- a/include/boost/spirit/x4/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/x4/core/detail/parse_into_container.hpp
@@ -93,12 +93,12 @@ namespace boost::spirit::x4::detail
     struct parse_into_container_base_impl
     {
         // Parser has attribute (synthesize; Attribute is a container)
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires (!parser_accepts_container_v<Parser, Attribute, Context>)
         [[nodiscard]] static constexpr bool
         call_synthesize(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
+            Context const& context, Attribute& attr
         ) // never noexcept (requires container insertion)
         {
             static_assert(!std::same_as<std::remove_const_t<Attribute>, unused_container_type>);
@@ -106,8 +106,8 @@ namespace boost::spirit::x4::detail
             using value_type = traits::container_value_t<Attribute>;
             value_type val; // default-initialize
 
-            static_assert(Parsable<Parser, It, Se, Context, RContext, value_type>);
-            if (!parser.parse(first, last, context, rcontext, val))
+            static_assert(Parsable<Parser, It, Se, Context, value_type>);
+            if (!parser.parse(first, last, context, val))
             {
                 return false;
             }
@@ -117,48 +117,48 @@ namespace boost::spirit::x4::detail
             return true;
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
             requires (!parser_accepts_container_v<Parser, unused_container_type, Context>)
         [[nodiscard]] static constexpr bool
         call_synthesize(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, unused_container_type const&
-        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, RContext, unused_type>)
+            Context const& context, unused_container_type const&
+        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, unused_type>)
         {
-            static_assert(Parsable<Parser, It, Se, Context, RContext, unused_type>);
-            return parser.parse(first, last, context, rcontext, unused);
+            static_assert(Parsable<Parser, It, Se, Context, unused_type>);
+            return parser.parse(first, last, context, unused);
         }
 
         // Parser has attribute (synthesize; Attribute is a container)
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires parser_accepts_container_v<Parser, Attribute, Context>
         [[nodiscard]] static constexpr bool
         call_synthesize(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
-        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, RContext, Attribute>)
+            Context const& context, Attribute& attr
+        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, Attribute>)
         {
-            static_assert(Parsable<Parser, It, Se, Context, RContext, Attribute>);
-            return parser.parse(first, last, context, rcontext, attr);
+            static_assert(Parsable<Parser, It, Se, Context, Attribute>);
+            return parser.parse(first, last, context, attr);
         }
 
         // Parser has attribute && it is NOT fusion sequence
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires
                 traits::has_attribute_v<Parser, Context> &&
                 (!fusion::traits::is_sequence<Attribute>::value)
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
+            Context const& context, Attribute& attr
         )
         {
             // TODO: reduce call stack while keeping maintainability
-            return parse_into_container_base_impl::call_synthesize(parser, first, last, context, rcontext, attr);
+            return parse_into_container_base_impl::call_synthesize(parser, first, last, context, attr);
         }
 
         // Parser has attribute && it is fusion sequence (NOT associative)
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires
                 traits::has_attribute_v<Parser, Context> &&
                 fusion::traits::is_sequence<Attribute>::value &&
@@ -166,16 +166,16 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
-        ) noexcept(noexcept(parse_into_container_base_impl::call_synthesize(parser, first, last, context, rcontext, fusion::front(attr))))
+            Context const& context, Attribute& attr
+        ) noexcept(noexcept(parse_into_container_base_impl::call_synthesize(parser, first, last, context, fusion::front(attr))))
         {
             static_assert(traits::has_size_v<Attribute, 1>, "Expecting a single element fusion sequence");
             // TODO: reduce call stack while keeping maintainability
-            return parse_into_container_base_impl::call_synthesize(parser, first, last, context, rcontext, fusion::front(attr));
+            return parse_into_container_base_impl::call_synthesize(parser, first, last, context, fusion::front(attr));
         }
 
         // Parser has attribute && it is fusion sequence (associative)
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires
                 traits::has_attribute_v<Parser, Context> &&
                 fusion::traits::is_sequence<Attribute>::value &&
@@ -183,15 +183,15 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
+            Context const& context, Attribute& attr
         ) // never noexcept (requires container insertion)
         {
             using attribute_type = traits::attribute_of_t<Parser, Context>;
             static_assert(traits::has_size_v<attribute_type, 2>, "To parse directly into fusion map, parser must produce 2 element attr");
 
             attribute_type attr_; // default-initialize
-            static_assert(Parsable<Parser, It, Se, Context, RContext, attribute_type>);
-            if (!parser.parse(first, last, context, rcontext, attr_))
+            static_assert(Parsable<Parser, It, Se, Context, attribute_type>);
+            if (!parser.parse(first, last, context, attr_))
             {
                 return false;
             }
@@ -206,26 +206,26 @@ namespace boost::spirit::x4::detail
         }
 
         // Parser has no attribute (pass unused)
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires (!traits::has_attribute_v<Parser, Context>)
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& /* attr */
-        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, RContext, unused_container_type>)
+            Context const& context, Attribute& /* attr */
+        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, unused_container_type>)
         {
-            // static_assert(Parsable<Parser, It, Se, Context, RContext, unused_container_type>);
-            return parser.parse(first, last, context, rcontext, unused_container);
+            // static_assert(Parsable<Parser, It, Se, Context, unused_container_type>);
+            return parser.parse(first, last, context, unused_container);
         }
     };
 
-    template <typename Parser, typename Context, typename RContext>
+    template <typename Parser, typename Context>
     struct parse_into_container_impl : parse_into_container_base_impl<Parser> {};
 
 
-    template <typename Parser, typename Context, typename RContext>
+    template <typename Parser, typename Context>
         requires Parser::handles_container
-    struct parse_into_container_impl<Parser, Context, RContext>
+    struct parse_into_container_impl<Parser, Context>
     {
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
         static constexpr bool pass_attibute_as_is = std::disjunction_v<
@@ -246,13 +246,13 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
+            Context const& context, Attribute& attr
         ) noexcept(noexcept(parse_into_container_base_impl<Parser>::call(
-            parser, first, last, context, rcontext, attr
+            parser, first, last, context, attr
         )))
         {
             return parse_into_container_base_impl<Parser>::call(
-                parser, first, last, context, rcontext, attr
+                parser, first, last, context, attr
             );
         }
 
@@ -261,11 +261,11 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, unused_container_type
-        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, RContext, unused_container_type>)
+            Context const& context, unused_container_type
+        ) noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, unused_container_type>)
         {
-            static_assert(Parsable<Parser, It, Se, Context, RContext, unused_container_type>);
-            return parser.parse(first, last, context, rcontext, unused_container);
+            static_assert(Parsable<Parser, It, Se, Context, unused_container_type>);
+            return parser.parse(first, last, context, unused_container);
         }
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
@@ -273,21 +273,21 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             Parser const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext, Attribute& attr
+            Context const& context, Attribute& attr
         ) // never noexcept (requires container insertion)
         {
             static_assert(!std::is_same_v<std::remove_const_t<Attribute>, unused_type>);
             static_assert(!std::is_same_v<std::remove_const_t<Attribute>, unused_container_type>);
 
-            static_assert(Parsable<Parser, It, Se, Context, RContext, Attribute>);
+            static_assert(Parsable<Parser, It, Se, Context, Attribute>);
 
             if (traits::is_empty(attr))
             {
-                return parser.parse(first, last, context, rcontext, attr);
+                return parser.parse(first, last, context, attr);
             }
 
             Attribute rest; // default-initialize
-            if (!parser.parse(first, last, context, rcontext, rest))
+            if (!parser.parse(first, last, context, rest))
             {
                 return false;
             }
@@ -302,14 +302,14 @@ namespace boost::spirit::x4::detail
 
     template <
         typename Parser, std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext, typename Attribute
+        typename Context, typename Attribute
     >
     [[nodiscard]] constexpr bool
     parse_into_container(
         Parser const& parser, It& first, Se const& last,
-        Context const& context, RContext& rcontext, Attribute& attr
-    ) noexcept(noexcept(parse_into_container_impl<Parser, Context, RContext>::call(
-        parser, first, last, context, rcontext, attr
+        Context const& context, Attribute& attr
+    ) noexcept(noexcept(parse_into_container_impl<Parser, Context>::call(
+        parser, first, last, context, attr
     )))
     {
         static_assert(
@@ -317,8 +317,8 @@ namespace boost::spirit::x4::detail
             "`unused_type` should not be passed to `parse_into_container`. Use `x4::assume_container(attr)`"
         );
 
-        return parse_into_container_impl<Parser, Context, RContext>::call(
-            parser, first, last, context, rcontext, attr
+        return parse_into_container_impl<Parser, Context>::call(
+            parser, first, last, context, attr
         );
     }
 

--- a/include/boost/spirit/x4/core/detail/parse_sequence.hpp
+++ b/include/boost/spirit/x4/core/detail/parse_sequence.hpp
@@ -233,14 +233,13 @@ namespace boost::spirit::x4::detail
     template <
         typename Parser,
         std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext, typename Attribute
+        typename Context, typename Attribute
     >
     [[nodiscard]] constexpr bool
     parse_sequence(
         Parser const& parser,
         It& first, Se const& last,
-        Context const& context, RContext& rcontext,
-        Attribute& attr
+        Context const& context, Attribute& attr
     )
     {
         using partition = partition_attribute<
@@ -258,8 +257,8 @@ namespace boost::spirit::x4::detail
 
         It const first_saved = first;
 
-        if (parser.left.parse(first, last, context, rcontext, l_attr) &&
-            parser.right.parse(first, last, context, rcontext, r_attr)
+        if (parser.left.parse(first, last, context, l_attr) &&
+            parser.right.parse(first, last, context, r_attr)
         )
         {
             return true;
@@ -274,62 +273,57 @@ namespace boost::spirit::x4::detail
     template <
         typename Parser,
         std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext, typename Attribute
+        typename Context, typename Attribute
     >
         requires pass_sequence_container_attribute<Parser, Context>
     [[nodiscard]] constexpr bool
     parse_sequence_container(
         Parser const& parser,
         It& first, Se const& last,
-        Context const& context, RContext& rcontext,
-        Attribute& attr
+        Context const& context, Attribute& attr
     )
-        noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, RContext, Attribute>)
+        noexcept(is_nothrow_parsable_v<Parser, It, Se, Context, Attribute>)
     {
-        static_assert(Parsable<Parser, It, Se, Context, RContext, Attribute>);
-        return parser.parse(first, last, context, rcontext, attr);
+        static_assert(Parsable<Parser, It, Se, Context, Attribute>);
+        return parser.parse(first, last, context, attr);
     }
 
     template <
         typename Parser,
         std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext,
-        typename Attribute
+        typename Context, typename Attribute
     >
         requires (!pass_sequence_container_attribute<Parser, Context>)
     [[nodiscard]] constexpr bool
     parse_sequence_container(
         Parser const& parser,
         It& first, Se const& last,
-        Context const& context, RContext& rcontext,
-        Attribute& attr
+        Context const& context, Attribute& attr
     )
-        noexcept(noexcept(detail::parse_into_container(parser, first, last, context, rcontext, attr)))
+        noexcept(noexcept(detail::parse_into_container(parser, first, last, context, attr)))
     {
-        return detail::parse_into_container(parser, first, last, context, rcontext, attr);
+        return detail::parse_into_container(parser, first, last, context, attr);
     }
 
     template <
         typename Parser,
         std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext
-    >
+        typename Context>
     [[nodiscard]] constexpr bool
     parse_sequence(
         Parser const& parser,
         It& first, Se const& last,
-        Context const& context, RContext& rcontext,
-        traits::CategorizedAttr<traits::container_attribute> auto& attr
+        Context const& context, traits::CategorizedAttr<traits::container_attribute> auto& attr
     )
         noexcept(
             std::is_nothrow_copy_assignable_v<It> &&
-            noexcept(detail::parse_sequence_container(parser.left, first, last, context, rcontext, attr)) &&
-            noexcept(detail::parse_sequence_container(parser.right, first, last, context, rcontext, attr))
+            noexcept(detail::parse_sequence_container(parser.left, first, last, context, attr)) &&
+            noexcept(detail::parse_sequence_container(parser.right, first, last, context, attr))
         )
     {
         It const first_saved = first;
-        if (detail::parse_sequence_container(parser.left, first, last, context, rcontext, attr) &&
-            detail::parse_sequence_container(parser.right, first, last, context, rcontext, attr)
+        if (detail::parse_sequence_container(parser.left, first, last, context, attr) &&
+            detail::parse_sequence_container(parser.right, first, last, context, attr)
         )
         {
             return true;
@@ -359,41 +353,37 @@ namespace boost::spirit::x4::detail
     template <
         typename Parser,
         std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext
-    >
+        typename Context>
         requires (!assoc_sequence_should_split<Parser, Context>)
     [[nodiscard]] constexpr bool
     parse_sequence(
         Parser const& parser,
         It& first, Se const& last,
-        Context const& context, RContext& rcontext,
-        traits::CategorizedAttr<traits::associative_attribute> auto& attr
-    ) noexcept(noexcept(detail::parse_into_container(parser, first, last, context, rcontext, attr)))
+        Context const& context, traits::CategorizedAttr<traits::associative_attribute> auto& attr
+    ) noexcept(noexcept(detail::parse_into_container(parser, first, last, context, attr)))
     {
-	    return detail::parse_into_container(parser, first, last, context, rcontext, attr);
+	    return detail::parse_into_container(parser, first, last, context, attr);
     }
 
     template <
         typename Parser,
         std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext
-    >
+        typename Context>
         requires assoc_sequence_should_split<Parser, Context>
     [[nodiscard]] constexpr bool
     parse_sequence(
         Parser const& parser,
         It& first, Se const& last,
-        Context const& context, RContext& rcontext,
-        traits::CategorizedAttr<traits::associative_attribute> auto& attr
+        Context const& context, traits::CategorizedAttr<traits::associative_attribute> auto& attr
     ) noexcept(
         std::is_nothrow_copy_assignable_v<It> &&
-        noexcept(parser.left.parse(first, last, context, rcontext, attr)) &&
-        noexcept(parser.right.parse(first, last, context, rcontext, attr))
+        noexcept(parser.left.parse(first, last, context, attr)) &&
+        noexcept(parser.right.parse(first, last, context, attr))
     )
     {
         It const first_saved = first;
-        if (parser.left.parse(first, last, context, rcontext, attr) &&
-            parser.right.parse(first, last, context, rcontext, attr)
+        if (parser.left.parse(first, last, context, attr) &&
+            parser.right.parse(first, last, context, attr)
         )
         {
             return true;
@@ -402,8 +392,8 @@ namespace boost::spirit::x4::detail
         return false;
     }
 
-    template <typename Left, typename Right, typename Context, typename RContext>
-    struct parse_into_container_impl<sequence<Left, Right>, Context, RContext>
+    template <typename Left, typename Right, typename Context>
+    struct parse_into_container_impl<sequence<Left, Right>, Context>
     {
         using parser_type = sequence<Left, Right>;
 
@@ -418,14 +408,13 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             parser_type const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext,
-            Attribute& attr
+            Context const& context, Attribute& attr
         ) noexcept(noexcept(parse_into_container_base_impl<parser_type>::call(
-            parser, first, last, context, rcontext, attr
+            parser, first, last, context, attr
         )))
         {
             return parse_into_container_base_impl<parser_type>::call(
-                parser, first, last, context, rcontext, attr
+                parser, first, last, context, attr
             );
         }
 
@@ -434,8 +423,7 @@ namespace boost::spirit::x4::detail
         [[nodiscard]] static constexpr bool
         call(
             parser_type const& parser, It& first, Se const& last,
-            Context const& context, RContext& rcontext,
-            Attribute& attr
+            Context const& context, Attribute& attr
         ) // never noexcept (requires container insertion)
         {
             // inform user what went wrong if we jumped here in attempt to
@@ -457,12 +445,12 @@ namespace boost::spirit::x4::detail
                 std::is_same_v<std::remove_const_t<Attribute>, unused_container_type>
             )
             {
-                return detail::parse_sequence(parser, first, last, context, rcontext, x4::assume_container(attr));
+                return detail::parse_sequence(parser, first, last, context, x4::assume_container(attr));
             }
             else
             {
                 Attribute attr_;
-                if (!detail::parse_sequence(parser, first, last, context, rcontext, attr_))
+                if (!detail::parse_sequence(parser, first, last, context, attr_))
                 {
                     return false;
                 }

--- a/include/boost/spirit/x4/core/expectation.hpp
+++ b/include/boost/spirit/x4/core/expectation.hpp
@@ -13,156 +13,93 @@
 #include <boost/spirit/x4/core/parser.hpp> // for `x4::what`
 #include <boost/spirit/x4/core/unused.hpp>
 #include <boost/spirit/x4/core/context.hpp>
-#include <boost/spirit/x4/traits/optional_traits.hpp>
 
+#include <concepts>
 #include <iterator>
 #include <string>
 #include <type_traits>
 #include <utility>
 
+#include <cassert>
+
 namespace boost::spirit::x4
 {
-    struct expectation_failure_tag;
+    struct expectation_failure_tag
+    {
+        static constexpr bool is_unique = true;
+    };
 
     template <std::forward_iterator It>
     struct expectation_failure
     {
-        template <typename Which>
-            requires std::is_constructible_v<std::string, Which>
-        constexpr expectation_failure(It where, Which&& which)
-            noexcept(std::is_nothrow_copy_constructible_v<It> && std::is_nothrow_constructible_v<std::string, Which>)
+        constexpr expectation_failure() = default;
+
+        template <typename WhichT>
+            requires std::is_constructible_v<std::string, WhichT>
+        constexpr expectation_failure(It where, WhichT&& which)
+            noexcept(std::is_nothrow_copy_constructible_v<It> && std::is_nothrow_constructible_v<std::string, WhichT>)
             : where_(where)
-            , which_(std::forward<Which>(which))
-        {}
+            , which_(std::forward<WhichT>(which))
+        {
+            if (which_.empty())
+            {
+                which_ = "(unknown location)";
+            }
+        }
 
         [[nodiscard]]
-        constexpr It const& where() const noexcept { return where_; }
+        constexpr It const& where() const noexcept
+        {
+            assert(this->has_value());
+            return where_;
+        }
 
         [[nodiscard]]
-        constexpr std::string const& which() const noexcept { return which_; }
+        constexpr std::string const& which() const noexcept
+        {
+            assert(this->has_value());
+            return which_;
+        }
+
+        constexpr void clear() noexcept
+        {
+            which_.clear();
+        }
+
+        template <typename WhichT>
+            requires std::is_constructible_v<std::string, WhichT>
+        constexpr void emplace(It where, WhichT&& which)
+            noexcept(std::is_nothrow_move_assignable_v<It> && std::is_nothrow_assignable_v<std::string&, WhichT>)
+        {
+            where_ = std::move(where);
+            which_ = std::forward<WhichT>(which);
+        }
+
+        [[nodiscard]] constexpr explicit operator bool() const noexcept { return !which_.empty(); }
+        [[nodiscard]] constexpr bool has_value() const noexcept { return !which_.empty(); }
+
+        constexpr void swap(expectation_failure& other)
+            noexcept(std::is_nothrow_swappable_v<It> && std::is_nothrow_swappable_v<std::string>)
+        {
+            using std::swap;
+            swap(where_, other.where_);
+            swap(which_, other.which_);
+        }
 
     private:
-        It where_;
+        It where_{};
         std::string which_;
     };
 
-
-    template <typename Context>
-    using expectation_failure_t = std::remove_cv_t<std::remove_reference_t<
-        decltype(x4::get<expectation_failure_tag>(std::declval<Context const&>()))>>;
-
     template <std::forward_iterator It>
-    using expectation_failure_optional =
-        typename traits::build_optional<expectation_failure<It>>::type;
+    constexpr void swap(expectation_failure<It>& a, expectation_failure<It>& b)
+        noexcept(std::is_nothrow_swappable_v<It> && std::is_nothrow_swappable_v<std::string>)
+    {
+        a.swap(b);
+    }
 
     template <typename Context>
-    constexpr bool has_expectation_failure_context = !std::is_same_v<expectation_failure_t<Context>, unused_type>;
-
-    // x4::where(x), x4::which(x)
-    // Convenient accessors for absorbing the variation of
-    // optional/reference_wrapper interfaces.
-
-    // beware ADL - we should avoid overgeneralization here.
-
-    namespace expectation_failure_helpers
-    {
-        // bare type
-        template <std::forward_iterator It>
-        [[nodiscard]]
-        constexpr decltype(auto) where(expectation_failure<It> const& failure) noexcept { return failure.where(); }
-
-        template <std::forward_iterator It>
-        [[nodiscard]]
-        constexpr decltype(auto) which(expectation_failure<It> const& failure) noexcept { return failure.which(); }
-
-        // std::optional
-        template <std::forward_iterator It>
-        [[nodiscard]]
-        constexpr decltype(auto) where(std::optional<expectation_failure<It>> const& failure) noexcept { return failure->where(); }
-
-        template <std::forward_iterator It>
-        [[nodiscard]]
-        constexpr decltype(auto) which(std::optional<expectation_failure<It>> const& failure) noexcept { return failure->which(); }
-
-        // std::optional + std::reference_wrapper
-        template <std::forward_iterator It>
-        [[nodiscard]]
-        constexpr decltype(auto) where(std::reference_wrapper<std::optional<expectation_failure<It>>> const& failure) noexcept { return failure.get()->where(); }
-
-        template <std::forward_iterator It>
-        [[nodiscard]]
-        constexpr decltype(auto) which(std::reference_wrapper<std::optional<expectation_failure<It>>> const& failure) noexcept { return failure.get()->which(); }
-
-    } // expectation_failure_helpers
-
-    using expectation_failure_helpers::where;
-    using expectation_failure_helpers::which;
-
-    namespace detail {
-        inline constexpr bool has_expectation_failure_impl(unused_type const&) noexcept = delete;
-
-        [[nodiscard]] inline constexpr bool has_expectation_failure_impl(bool& failure) noexcept
-        {
-            return failure;
-        }
-
-        template <std::forward_iterator It>
-        [[nodiscard]] constexpr bool has_expectation_failure_impl(std::optional<expectation_failure<It>> const& failure) noexcept
-        {
-            return failure.has_value();
-        }
-
-        template <typename T>
-        [[nodiscard]] constexpr bool has_expectation_failure_impl(std::reference_wrapper<T> const& ref) noexcept
-        {
-            return detail::has_expectation_failure_impl(ref.get());
-        }
-
-
-        template <std::forward_iterator It, typename T>
-        constexpr void set_expectation_failure_impl(bool& failure, T&& value)
-            noexcept(std::is_nothrow_assignable_v<bool&, T>)
-        {
-            failure = std::forward<T>(value);
-        }
-
-        template <std::forward_iterator It, typename T>
-        constexpr void set_expectation_failure_impl(std::optional<expectation_failure<It>>& failure, T&& value)
-            noexcept(std::is_nothrow_assignable_v<std::optional<expectation_failure<It>>&, T>)
-        {
-            failure = std::forward<T>(value);
-        }
-
-        template <typename AnyExpectationFailure, typename T>
-        constexpr void set_expectation_failure_impl(std::reference_wrapper<AnyExpectationFailure>& failure, T&& value)
-            noexcept(std::is_nothrow_assignable_v<AnyExpectationFailure&, T>)
-        {
-            detail::set_expectation_failure_impl(failure.get(), std::forward<T>(value));
-        }
-
-
-        template <std::forward_iterator It>
-        constexpr void clear_expectation_failure_impl(unused_type const&) noexcept = delete;
-
-        template <std::forward_iterator It>
-        constexpr void clear_expectation_failure_impl(bool& failure) noexcept
-        {
-            failure = false;
-        }
-
-        template <std::forward_iterator It>
-        constexpr void clear_expectation_failure_impl(std::optional<expectation_failure<It>>& failure) noexcept
-        {
-            failure.reset();
-        }
-
-        template <typename T>
-        constexpr void clear_expectation_failure_impl(std::reference_wrapper<T>& ref) noexcept
-        {
-            return detail::clear_expectation_failure_impl(ref.get());
-        }
-
-    } // detail
+    using expectation_failure_t = get_context_plain_t<expectation_failure_tag, Context>;
 
     template <typename Context>
     [[nodiscard]]
@@ -170,91 +107,34 @@ namespace boost::spirit::x4
     {
         using T = expectation_failure_t<Context>;
         static_assert(
-            !std::is_same_v<unused_type, T>,
+            !std::same_as<unused_type, T>,
             "Context type was not specified for x4::expectation_failure_tag. "
             "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
             "Note that you must also bind the context to your skipper."
         );
-        return detail::has_expectation_failure_impl(x4::get<expectation_failure_tag>(context));
+        return x4::get<expectation_failure_tag>(context).has_value();
     }
 
     //
-    // Creation of a brand new expectation_failure instance.
+    // Creation of a brand-new expectation_failure instance.
     // This is the primary overload.
     //
     template <std::forward_iterator It, typename Subject, typename Context>
     constexpr void set_expectation_failure(
-        It const& where,
+        It where,
         Subject const& subject,
         Context const& context
     )
+        noexcept(noexcept(x4::get<expectation_failure_tag>(context).emplace(std::move(where), x4::what(subject))))
     {
         using T = expectation_failure_t<Context>;
         static_assert(
-            !std::is_same_v<unused_type, T>,
+            !std::same_as<unused_type, T>,
             "Context type was not specified for x4::expectation_failure_tag. "
             "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
             "Note that you must also bind the context to your skipper."
         );
-
-        if constexpr (std::is_same_v<T, bool>)
-        {
-            (void)where;
-            (void)subject;
-            detail::set_expectation_failure_impl(
-                x4::get<expectation_failure_tag>(context),
-                true
-            );
-        }
-        else
-        {
-            detail::set_expectation_failure_impl(
-                x4::get<expectation_failure_tag>(context),
-                expectation_failure<It>(where, x4::what(subject))
-            );
-        }
-    }
-
-    //
-    // Copy-assignment of existing expectation_failure instance.
-    //
-    // When you're in the situation where this functionality is
-    // *really* needed, it essentially means that you have
-    // multiple valid exceptions at the same time.
-    //
-    // There are only two decent situations that I can think of:
-    //
-    //   (a) When you are writing a custom parser procedure with very specific characteristics:
-    //       1. You're forking a context.
-    //       2. Your parser class has delegated some process to child parser(s).
-    //       3. The child parser(s) have raised an exceptation_failure.
-    //       4. You need to propagate the failure back to the parent context.
-    //
-    //   (b) When you truly need a nested exception.
-    //       That is, you're trying to preserve a nested exception structure
-    //       raised by nested directive: e.g. `x4::expect[x4::expect[p]]`.
-    //       Note that all builtin primitives just save the first error,
-    //       so this structure does not exist in core (as of now).
-    //
-    template <typename AnyExpectationFailure, typename Context>
-    constexpr void set_expectation_failure(
-        AnyExpectationFailure const& existing_failure,
-        Context const& context
-    ) {
-        using T = expectation_failure_t<Context>;
-        static_assert(
-            !std::is_same_v<T, unused_type>,
-            "Context type was not specified for x4::expectation_failure_tag. "
-            "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
-            "Note that you must also bind the context to your skipper."
-        );
-
-        static_assert(
-            std::is_assignable_v<T, AnyExpectationFailure const&>,
-            "previous/current expectation failure types should be compatible"
-        );
-
-        detail::set_expectation_failure_impl(x4::get<expectation_failure_tag>(context), existing_failure);
+        x4::get<expectation_failure_tag>(context).emplace(std::move(where), x4::what(subject));
     }
 
     template <typename Context>
@@ -263,7 +143,7 @@ namespace boost::spirit::x4
     {
         using T = expectation_failure_t<Context>;
         static_assert(
-            !std::is_same_v<T, unused_type>,
+            !std::same_as<T, unused_type>,
             "Context type was not specified for x4::expectation_failure_tag. "
             "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
             "Note that you must also bind the context to your skipper."
@@ -277,12 +157,12 @@ namespace boost::spirit::x4
     {
         using T = expectation_failure_t<Context>;
         static_assert(
-            !std::is_same_v<T, unused_type>,
+            !std::same_as<T, unused_type>,
             "Context type was not specified for x4::expectation_failure_tag. "
             "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
             "Note that you must also bind the context to your skipper."
         );
-        detail::clear_expectation_failure_impl(x4::get<expectation_failure_tag>(context));
+        x4::get<expectation_failure_tag>(context).clear();
     }
 
 } // boost::spirit::x4

--- a/include/boost/spirit/x4/core/parser.hpp
+++ b/include/boost/spirit/x4/core/parser.hpp
@@ -99,13 +99,9 @@ namespace boost::spirit::x4
         }
     };
 
-    struct unary_category;
-    struct binary_category;
-
     template <typename Subject, typename Derived>
     struct unary_parser : parser<Derived>
     {
-        using category = unary_category;
         using subject_type = Subject;
 
         static constexpr bool has_action = Subject::has_action;
@@ -125,7 +121,6 @@ namespace boost::spirit::x4
     template <typename Left, typename Right, typename Derived>
     struct binary_parser : parser<Derived>
     {
-        using category = binary_category;
         using left_type = Left;
         using right_type = Right;
 

--- a/include/boost/spirit/x4/core/parser.hpp
+++ b/include/boost/spirit/x4/core/parser.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/spirit/config.hpp>
 #include <boost/spirit/x4/core/unused.hpp>
+#include <boost/spirit/x4/core/context.hpp>
 #include <boost/spirit/x4/traits/attribute.hpp>
 
 #include <iterator>
@@ -33,26 +34,26 @@ namespace boost::spirit::x4
     {
         struct parser_base {};
         struct parser_id;
-    } // detail
 
+        struct arbitrary_context_tag; // not defined
+        using arbitrary_context_type = context<arbitrary_context_tag, int>;
+
+    } // detail
 
     template <typename T>
     concept X4Attribute =
-        std::is_object_v<T> && // implies not reference
+        std::is_same_v<std::remove_const_t<T>, unused_type> ||
+        std::is_same_v<std::remove_const_t<T>, unused_container_type> ||
         (
-            std::is_same_v<std::remove_const_t<T>, unused_type> ||
-            std::is_same_v<std::remove_const_t<T>, unused_container_type> ||
-            (
-                !std::is_base_of_v<detail::parser_base, std::remove_const_t<T>> &&
-                // std::default_initializable<T> &&
-                std::move_constructible<T> &&
-                std::assignable_from<T&, T>
-            )
+            std::is_object_v<T> && // implies not reference
+            !std::is_base_of_v<detail::parser_base, std::remove_const_t<T>> &&
+            // std::default_initializable<T> &&
+            std::move_constructible<T> &&
+            std::assignable_from<T&, T>
         );
 
-
     template <typename Derived>
-    struct parser : detail::parser_base
+    struct parser : private detail::parser_base
     {
         static_assert(!std::is_reference_v<Derived>);
         using derived_type = Derived;
@@ -106,6 +107,8 @@ namespace boost::spirit::x4
 
         static constexpr bool has_action = Subject::has_action;
 
+        constexpr unary_parser() = default;
+
         template <typename SubjectT>
             requires
                 (!std::is_same_v<std::remove_cvref_t<SubjectT>, unary_parser>) &&
@@ -115,7 +118,7 @@ namespace boost::spirit::x4
             : subject(std::forward<SubjectT>(subject))
         {}
 
-        Subject subject;
+        BOOST_SPIRIT_NO_UNIQUE_ADDRESS Subject subject;
     };
 
     template <typename Left, typename Right, typename Derived>
@@ -126,6 +129,8 @@ namespace boost::spirit::x4
 
         static constexpr bool has_action = left_type::has_action || right_type::has_action;
 
+        constexpr binary_parser() = default;
+
         template <typename LeftT, typename RightT>
             requires std::is_constructible_v<Left, LeftT> && std::is_constructible_v<Right, RightT>
         constexpr binary_parser(LeftT&& left, RightT&& right)
@@ -134,8 +139,8 @@ namespace boost::spirit::x4
             , right(std::forward<RightT>(right))
         {}
 
-        Left left;
-        Right right;
+        BOOST_SPIRIT_NO_UNIQUE_ADDRESS Left left;
+        BOOST_SPIRIT_NO_UNIQUE_ADDRESS Right right;
     };
 
     // as_parser: convert a type, T, into a parser.
@@ -299,12 +304,17 @@ namespace boost::spirit::x4
 
     template <typename T>
     concept X4ExplicitSubject =
-        std::is_base_of_v<detail::parser_base, std::remove_cvref_t<T>>;
+        std::is_base_of_v<detail::parser_base, std::remove_cvref_t<T>> &&
+        std::move_constructible<std::remove_cvref_t<T>>;
+        // Note: a lambda with a capture has a deleted move assignment operator,
+        // thus requiring move assignable here would make such `x4::action` to
+        // not satisfy this trait; we consider it too strict for now.
 
     template <typename T>
     concept X4ImplicitSubject =
+        !std::is_base_of_v<detail::parser_base, std::remove_cvref_t<T>> &&
         is_parser_castable_v<T> && // `as_parser(t)` is valid?
-        std::is_base_of_v<detail::parser_base, as_parser_plain_t<T>>;
+        X4ExplicitSubject<as_parser_t<T>>;
 
     // A type that models `X4Subject` can be used in generic directives
     // and operators. Note that this concept is iterator-agnostic.
@@ -355,21 +365,16 @@ namespace boost::spirit::x4
     constexpr bool is_parser_nothrow_constructible_v = is_parser_nothrow_constructible<Parser, T>::value;
 
 
-    template <
-        typename Parser,
-        typename It, // Don't constrain these; just let `static_assert` be engaged for friendly errors
-        typename Se,
-        typename Context,
-        typename Attribute
-    >
+    template <typename Parser, typename It, typename Se, typename Context, typename Attr>
     struct is_parsable
     {
-        static_assert(X4Subject<Parser>);
+        static_assert(X4ExplicitSubject<Parser>);
         static_assert(!std::is_reference_v<It>);
         static_assert(std::forward_iterator<It>);
         static_assert(std::sentinel_for<Se, It>);
         static_assert(!std::is_reference_v<Context>);
-        static_assert(!std::is_reference_v<Attribute>);
+        static_assert(!std::is_reference_v<Attr>);
+        static_assert(X4Attribute<Attr>);
 
         static constexpr bool value = requires(Parser const& p) // mutable parser use case is currently unknown
         {
@@ -378,34 +383,42 @@ namespace boost::spirit::x4
                     std::declval<It&>(), // first
                     std::declval<Se>(), // last
                     std::declval<Context const&>(), // context
-                    std::declval<Attribute&>() // attr
+                    std::declval<Attr&>() // attr
                 )
-            } -> std::convertible_to<bool>;
+            } -> std::same_as<bool>;
         };
+
+        static_assert(!requires(Parser const& p)
+        {
+            {
+                p.parse(
+                    std::declval<It&>(), // first
+                    std::declval<Se>(), // last
+                    std::declval<Context const&>(), // context
+                    std::declval<unused_type const&>(), // rcontext
+                    std::declval<Attr&>() // attr
+                )
+            } -> std::same_as<bool>;
+        }, "X4 can now determine `RContext` automatically. Remove `RContext` from your parser.");
     };
 
-    template <typename Parser, typename It, typename Se, typename Context, typename Attribute>
-    constexpr bool is_parsable_v = is_parsable<Parser, It, Se, Context, Attribute>::value;
+    template <typename Parser, typename It, typename Se, typename Context, typename Attr>
+    constexpr bool is_parsable_v = is_parsable<Parser, It, Se, Context, Attr>::value;
 
-    template <typename Parser, typename It, typename Se, typename Context, typename Attribute>
-    concept Parsable = is_parsable<Parser, It, Se, Context, Attribute>::value;
+    template <typename Parser, typename It, typename Se, typename Context, typename Attr>
+    concept Parsable = is_parsable<Parser, It, Se, Context, Attr>::value;
     // ^^^ this must be concept in order to provide better diagnostics (e.g. on MSVC)
 
-    template <
-        typename Parser,
-        typename It, // Don't constrain these; just let `static_assert` be engaged for friendly errors
-        typename Se,
-        typename Context,
-        typename Attribute
-    >
+    template <typename Parser, typename It, typename Se, typename Context, typename Attr>
     struct is_nothrow_parsable
     {
-        static_assert(X4Subject<Parser>);
+        static_assert(X4ExplicitSubject<Parser>);
         static_assert(!std::is_reference_v<It>);
         static_assert(std::forward_iterator<It>);
         static_assert(std::sentinel_for<Se, It>);
         static_assert(!std::is_reference_v<Context>);
-        static_assert(!std::is_reference_v<Attribute>);
+        static_assert(!std::is_reference_v<Attr>);
+        static_assert(X4Attribute<Attr>);
 
         static constexpr bool value = requires(Parser const& p) // mutable parser use case is currently unknown
         {
@@ -414,14 +427,27 @@ namespace boost::spirit::x4
                     std::declval<It&>(), // first
                     std::declval<Se>(), // last
                     std::declval<Context const&>(), // context
-                    std::declval<Attribute&>() // attr
+                    std::declval<Attr&>() // attr
                 )
-            } noexcept -> std::convertible_to<bool>;
+            } noexcept -> std::same_as<bool>;
         };
+
+        static_assert(!requires(Parser const& p)
+        {
+            {
+                p.parse(
+                    std::declval<It&>(), // first
+                    std::declval<Se>(), // last
+                    std::declval<Context const&>(), // context
+                    std::declval<unused_type const&>(), // rcontext
+                    std::declval<Attr&>() // attr
+                )
+            } /*noexcept*/ -> std::same_as<bool>;
+        }, "X4 can now determine `RContext` automatically. Remove `RContext` from your parser.");
     };
 
-    template <typename Parser, typename It, typename Se, typename Context, typename Attribute>
-    constexpr bool is_nothrow_parsable_v = is_nothrow_parsable<Parser, It, Se, Context, Attribute>::value;
+    template <typename Parser, typename It, typename Se, typename Context, typename Attr>
+    constexpr bool is_nothrow_parsable_v = is_nothrow_parsable<Parser, It, Se, Context, Attr>::value;
 
 
     template <typename Parser, class It, class Se>
@@ -441,8 +467,8 @@ namespace boost::spirit::x4
     //
     // For `Parser` to model `X4Parser`, the following conditions must be satisfied:
     //   -- the expression `x4::as_parser(p)` is well-formed in unevaluated context, and
-    //   -- the expression `cp.parse(it, se, x4::unused, x4::unused, x4::unused)`
-    //      is well-formed and the return type is convertible to `bool`, where `cp` denotes a
+    //   -- the expression `cp.parse(it, se, x4::unused, x4::unused)`
+    //      is well-formed and the return type is same as `bool`, where `cp` denotes a
     //      const lvalue reference to the result of the expression `x4::as_parser(p)`.
     //
     // Although some exotic user-defined parser could be designed to operate on the very
@@ -450,8 +476,8 @@ namespace boost::spirit::x4
     // accept `unused_type` for `Context` and `Attribute`. This is because
     // core parsers of Spirit have historically been assuming natural use of `unused_type`
     // in many locations.
-    template <typename Parser, class It, class Se> // TODO
-    concept X4Parser = X4Subject<Parser>; // X4ExplicitParser<Parser, It, Se> || X4ImplicitParser<Parser, It, Se>;
+    template <typename Parser, class It, class Se>
+    concept X4Parser = X4ExplicitParser<Parser, It, Se> || X4ImplicitParser<Parser, It, Se>;
 
 
     // The runtime type info that can be obtained via `x4::what(p)`.
@@ -505,12 +531,13 @@ namespace boost::spirit::x4
 namespace boost::spirit::x4::traits
 {
     template <typename Subject, typename Derived, typename Context>
-    struct has_attribute<x4::unary_parser<Subject, Derived>, Context>
+    struct has_attribute<unary_parser<Subject, Derived>, Context>
         : has_attribute<Subject, Context> {};
 
     template <typename Left, typename Right, typename Derived, typename Context>
-    struct has_attribute<x4::binary_parser<Left, Right, Derived>, Context>
+    struct has_attribute<binary_parser<Left, Right, Derived>, Context>
         : std::disjunction<has_attribute<Left, Context>, has_attribute<Right, Context>> {};
+
 } // boost::spirit::x4::traits
 
 #endif

--- a/include/boost/spirit/x4/core/skip_over.hpp
+++ b/include/boost/spirit/x4/core/skip_over.hpp
@@ -22,7 +22,10 @@
 namespace boost::spirit::x4
 {
     // Tag used to find the skipper from the context
-    struct skipper_tag;
+    struct skipper_tag
+    {
+        static constexpr bool is_unique = false;
+    };
 
     // Move the /first/ iterator to the first non-matching position
     // given a skip-parser. The function is a no-op if unused_type or
@@ -96,10 +99,8 @@ namespace boost::spirit::x4
         };
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, X4Subject Skipper>
-        constexpr void skip_over(
-            It& first, Se const& last, Context& context, Skipper const& skipper
-        )
-            noexcept(is_nothrow_parsable_v<Skipper, It, Se, typename skip_over_context<Context>::type, unused_type, unused_type>)
+        constexpr void skip_over(It& first, Se const& last, Context const& context, Skipper const& skipper)
+            noexcept(is_nothrow_parsable_v<Skipper, It, Se, typename skip_over_context<Context>::type, unused_type>)
         {
             if constexpr (std::is_same_v<expectation_failure_t<Context>, unused_type>)
             {
@@ -117,7 +118,7 @@ namespace boost::spirit::x4
                 // If we encounter this branch in any other situations,
                 // that should be a BUG of `expectation_failure` logic.
 
-                while (skipper.parse(first, last, unused, unused, unused))
+                while (skipper.parse(first, last, unused, unused))
                     /* loop */;
             }
             else
@@ -150,13 +151,13 @@ namespace boost::spirit::x4
                 auto const local_ctx = x4::make_context<expectation_failure_tag>(
                     x4::get<expectation_failure_tag>(context));
 
-                while (skipper.parse(first, last, local_ctx, unused, unused))
+                while (skipper.parse(first, last, local_ctx, unused))
                     /* loop */;
             }
         }
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
-        constexpr void skip_over(It&, Se const&, Context&, unused_type) noexcept
+        constexpr void skip_over(It&, Se const&, Context&, unused_type const&) noexcept
         {
         }
 

--- a/include/boost/spirit/x4/core/unused.hpp
+++ b/include/boost/spirit/x4/core/unused.hpp
@@ -16,11 +16,19 @@
 
 namespace boost::spirit::x4
 {
+    template <typename ID, typename T, typename Next>
+    struct context;
+
     struct unused_type
     {
         constexpr explicit unused_type() noexcept = default;
 
         // unused_type can masquerade as an empty context (see context.hpp)
+
+        template <typename ID, typename T, typename Next>
+        [[deprecated("If your parser don't need a `context`, just accept it by `auto const&` and discard it.")]]
+        /* not explicit */ constexpr unused_type(context<ID, T, Next> const&) noexcept
+        {}
 
         [[nodiscard]] static constexpr unused_type get(auto) noexcept
         {

--- a/include/boost/spirit/x4/debug/detail/parse_callback.hpp
+++ b/include/boost/spirit/x4/debug/detail/parse_callback.hpp
@@ -1,0 +1,149 @@
+﻿#ifndef BOOST_SPIRIT_X4_X4_DEBUG_DETAIL_PARSE_CALLBACK_HPP
+#define BOOST_SPIRIT_X4_X4_DEBUG_DETAIL_PARSE_CALLBACK_HPP
+
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#include <boost/spirit/x4/core/expectation.hpp>
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x4::detail {
+
+template <typename ID, typename It, typename Se, typename Context>
+concept HasImmutableOnErrorOverload =
+    std::forward_iterator<It> &&
+    std::sentinel_for<Se, It> &&
+    requires(ID& id) { // Note: `ID` should be non-const
+        id.on_error(
+            std::declval<It const&>(),
+            std::declval<Se const&>(),
+            std::declval<expectation_failure<It> const&>(),
+            std::declval<Context const&>()
+        );
+    };
+
+template <typename ID, typename It, typename Se, typename Context>
+concept HasMutableOnErrorOverload =
+    std::forward_iterator<It> &&
+    std::sentinel_for<Se, It> &&
+    requires(ID& id) { // Note: `ID` should be non-const
+        id.on_error(
+            std::declval<It&>(),
+            std::declval<Se&>(),
+            std::declval<expectation_failure<It> const&>(),
+            std::declval<Context const&>()
+        );
+    };
+
+template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
+struct has_on_error : std::false_type {};
+
+template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
+    requires HasImmutableOnErrorOverload<ID, It, Se, Context>
+struct has_on_error<ID, It, Se, Context> : std::true_type
+{
+    // We intentionally make this hard error to prevent error-prone definition
+    static_assert(
+        std::is_void_v<
+            decltype(std::declval<ID&>().on_error(
+                std::declval<It const&>(),
+                std::declval<Se const&>(),
+                std::declval<expectation_failure<It> const&>(),
+                std::declval<Context const&>()
+            ))
+        >,
+        "The return type of `on_error` should be `void`."
+    );
+};
+
+template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
+    requires
+        (!HasImmutableOnErrorOverload<ID, It, Se, Context>) &&
+        HasMutableOnErrorOverload<ID, It, Se, Context>
+struct has_on_error<ID, It, Se, Context> : std::false_type
+{
+    // Historically, Spirit has passed mutable lvalue references of the iterators *as-is*
+    // to the `on_success`/`on_error` handlers. This behavior was simply a mistake, because:
+    //   (1) `on_success`/`on_error` mechanism was designed to be grammar-agnostic, and
+    //   (2) it does not make sense to modify the grammar-specific iterator on the
+    //       grammar-agnostic callback.
+    //
+    // Furthermore, any modification to X4's internal iterator variables may invoke
+    // undefined behavior, since we never provide any kind of guarantee on how the
+    // intermediate iterator variables are processed in X4's implementation details.
+    static_assert(
+        false,
+        "The `on_error` callback should only accept const reference or passed-by-value iterators."
+    );
+};
+
+template <typename ID, typename It, typename Se, typename Attribute, typename Context>
+concept HasImmutableOnSuccessOverload =
+    std::forward_iterator<It> &&
+    std::sentinel_for<Se, It> &&
+    requires(ID& id) { // Note: `ID` should be non-const
+        id.on_success(
+            std::declval<It const&>(),
+            std::declval<Se const&>(),
+            std::declval<Attribute&>(),
+            std::declval<Context const&>()
+        );
+    };
+
+template <typename ID, typename It, typename Se, typename Attribute, typename Context>
+concept HasMutableOnSuccessOverload =
+    std::forward_iterator<It> &&
+    std::sentinel_for<Se, It> &&
+    requires(ID& id) { // Note: `ID` should be non-const
+        id.on_success(
+            std::declval<It&>(),
+            std::declval<Se&>(),
+            std::declval<Attribute&>(),
+            std::declval<Context const&>()
+        );
+    };
+
+template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute, typename Context>
+struct has_on_success : std::false_type {};
+
+template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute, typename Context>
+    requires HasImmutableOnSuccessOverload<ID, It, Se, Attribute, Context>
+struct has_on_success<ID, It, Se, Attribute, Context> : std::true_type
+{
+    // We intentionally make this hard error to prevent error-prone definition
+    static_assert(
+        std::is_void_v<
+            decltype(std::declval<ID&>().on_success(
+                std::declval<It const&>(),
+                std::declval<Se const&>(),
+                std::declval<Attribute&>(),
+                std::declval<Context const&>()
+            ))
+        >,
+        "The return type of `on_success` should be `void`."
+    );
+};
+
+template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute, typename Context>
+    requires
+        (!HasImmutableOnSuccessOverload<ID, It, Se, Attribute, Context>) &&
+        HasMutableOnSuccessOverload<ID, It, Se, Attribute, Context>
+struct has_on_success<ID, It, Se, Attribute, Context> : std::false_type
+{
+    // For details, see the comments on `has_on_error`.
+    static_assert(
+        false,
+        "The `on_success` callback should only accept const reference or passed-by-value iterators."
+    );
+};
+
+} // boost::spirit::x4::detail
+
+#endif

--- a/include/boost/spirit/x4/debug/simple_trace.hpp
+++ b/include/boost/spirit/x4/debug/simple_trace.hpp
@@ -149,6 +149,45 @@ namespace boost::spirit::x4
             return tracer;
         }
 
+
+        // TODO: This should be customizable by users
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
+        struct [[nodiscard]] scoped_rule_debug
+        {
+            scoped_rule_debug(
+                char const* rule_name,
+                It const& first, Se const& last,
+                Attribute const& attr,
+                bool const* parse_ok
+            )
+                : parse_ok(parse_ok)
+                , rule_name(rule_name)
+                , first(first)
+                , last(last)
+                , attr(attr)
+                , f(detail::get_simple_trace())
+            {
+                f(first, last, attr, debug_handler_state::pre_parse, rule_name);
+            }
+
+            ~scoped_rule_debug()
+            {
+                f(
+                    first, last,
+                    attr,
+                    *parse_ok ? debug_handler_state::successful_parse : debug_handler_state::failed_parse,
+                    rule_name
+                );
+            }
+
+            bool const* parse_ok = nullptr;
+            char const* rule_name = nullptr;
+            It const& first;
+            Se const& last;
+            Attribute const& attr;
+            simple_trace_type& f;
+        };
+
     } // detail
 
 } // boost::spirit::x4

--- a/include/boost/spirit/x4/directive/confix.hpp
+++ b/include/boost/spirit/x4/directive/confix.hpp
@@ -47,22 +47,21 @@ namespace boost::spirit::x4
         {
         }
 
-        template<std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template<std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(
-            It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr
-        ) const noexcept(
-            std::is_nothrow_copy_assignable_v<It> &&
-            is_nothrow_parsable_v<Prefix, It, Se, Context, RContext, unused_type> &&
-            is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute> &&
-            is_nothrow_parsable_v<Postfix, It, Se, Context, RContext, unused_type>
-        )
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(
+                std::is_nothrow_copy_assignable_v<It> &&
+                is_nothrow_parsable_v<Prefix, It, Se, Context, unused_type> &&
+                is_nothrow_parsable_v<Subject, It, Se, Context, Attribute> &&
+                is_nothrow_parsable_v<Postfix, It, Se, Context, unused_type>
+            )
         {
             It const saved_first = first;
 
-            if (!(prefix_.parse(first, last, context, rcontext, unused) &&
-                  this->subject.parse(first, last, context, rcontext, attr) &&
-                  postfix_.parse(first, last, context, rcontext, unused))
+            if (!(prefix_.parse(first, last, context, unused) &&
+                  this->subject.parse(first, last, context, attr) &&
+                  postfix_.parse(first, last, context, unused))
             ) {
                 if (x4::has_expectation_failure(context))
                 {

--- a/include/boost/spirit/x4/directive/expect.hpp
+++ b/include/boost/spirit/x4/directive/expect.hpp
@@ -36,12 +36,12 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             // never noexcept; expectation failure requires construction of debug information
         {
-            bool const r = this->subject.parse(first, last, context, rcontext, attr);
+            bool const r = this->subject.parse(first, last, context, attr);
 
             // only the first failure is needed
             if (!r && !x4::has_expectation_failure(context))
@@ -76,18 +76,18 @@ namespace boost::spirit::x4
 namespace boost::spirit::x4::detail
 {
     // Special case handling for expect expressions.
-    template <typename Subject, typename Context, typename RContext>
-    struct parse_into_container_impl<expect_directive<Subject>, Context, RContext>
+    template <typename Subject, typename Context>
+    struct parse_into_container_impl<expect_directive<Subject>, Context>
     {
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
         [[nodiscard]] static constexpr bool
         call(
             expect_directive<Subject> const& parser,
-            It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr
+            It& first, Se const& last, Context const& context, Attribute& attr
         ) // never noexcept; expectation failure requires construction of debug information
         {
             bool const r = detail::parse_into_container(
-                parser.subject, first, last, context, rcontext, attr);
+                parser.subject, first, last, context, attr);
 
             // only the first error is needed
             if (!r && !x4::has_expectation_failure(context))

--- a/include/boost/spirit/x4/directive/lexeme.hpp
+++ b/include/boost/spirit/x4/directive/lexeme.hpp
@@ -40,13 +40,13 @@ namespace boost::spirit::x4
             x4::make_context<skipper_tag>(std::declval<unused_skipper_t<Context>&>(), std::declval<Context const&>())
         )>;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires has_skipper_v<Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(
                 noexcept(x4::skip_over(first, last, context)) &&
-                is_nothrow_parsable_v<Subject, It, Se, pre_skip_context_t<Context>, RContext, Attribute>
+                is_nothrow_parsable_v<Subject, It, Se, pre_skip_context_t<Context>, Attribute>
             )
         {
             x4::skip_over(first, last, context);
@@ -57,19 +57,18 @@ namespace boost::spirit::x4
             return this->subject.parse(
                 first, last,
                 x4::make_context<skipper_tag>(unused_skipper, context),
-                rcontext,
                 attr
             );
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires (!has_skipper_v<Context>)
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute>)
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, Attribute>)
         {
             //  no need to pre-skip if skipper is unused
-            return this->subject.parse(first, last, context, rcontext, attr);
+            return this->subject.parse(first, last, context, attr);
         }
     };
 

--- a/include/boost/spirit/x4/directive/matches.hpp
+++ b/include/boost/spirit/x4/directive/matches.hpp
@@ -39,15 +39,15 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(
-                is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type> &&
+                is_nothrow_parsable_v<Subject, It, Se, Context, unused_type> &&
                 noexcept(x4::move_to(std::declval<bool const&>(), attr))
             )
         {
-            bool const matched = this->subject.parse(first, last, context, rcontext, unused);
+            bool const matched = this->subject.parse(first, last, context, unused);
             if (x4::has_expectation_failure(context)) return false;
 
             x4::move_to(matched, attr);

--- a/include/boost/spirit/x4/directive/no_case.hpp
+++ b/include/boost/spirit/x4/directive/no_case.hpp
@@ -38,22 +38,20 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(noexcept(
                 this->subject.parse(
                     first, last,
-                    x4::make_context<detail::no_case_tag_t>(detail::no_case_tag, context),
-                    rcontext,
+                    x4::make_context<detail::case_compare_tag>(detail::case_compare_no_case, context),
                     attr
                 )
             ))
         {
             return this->subject.parse(
                 first, last,
-                x4::make_context<detail::no_case_tag_t>(detail::no_case_tag, context),
-                rcontext,
+                x4::make_context<detail::case_compare_tag>(detail::case_compare_no_case, context),
                 attr
             );
         }

--- a/include/boost/spirit/x4/directive/no_skip.hpp
+++ b/include/boost/spirit/x4/directive/no_skip.hpp
@@ -50,14 +50,13 @@ namespace boost::spirit::x4
         >;
 
     public:
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires has_skipper_v<Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(is_nothrow_parsable_v<
                 Subject, It, Se,
                 unused_skipper_context_t<Context>,
-                RContext,
                 Attribute
             >)
         {
@@ -69,18 +68,17 @@ namespace boost::spirit::x4
             return this->subject.parse(
                 first, last,
                 x4::make_context<skipper_tag>(unused_skipper, context),
-                rcontext,
                 attr
             );
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires (!has_skipper_v<Context>)
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute>)
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, Attribute>)
         {
-            return this->subject.parse(first, last, context, rcontext, attr);
+            return this->subject.parse(first, last, context, attr);
         }
     };
 

--- a/include/boost/spirit/x4/directive/omit.hpp
+++ b/include/boost/spirit/x4/directive/omit.hpp
@@ -38,13 +38,13 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute const& /* omitted */) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type>)
+        parse(It& first, Se const& last, Context const& context, Attribute const& /* omitted */) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, unused_type>)
         {
-            static_assert(Parsable<Subject, It, Se, Context, RContext, unused_type>);
-            return this->subject.parse(first, last, context, rcontext, unused);
+            static_assert(Parsable<Subject, It, Se, Context, unused_type>);
+            return this->subject.parse(first, last, context, unused);
         }
     };
 

--- a/include/boost/spirit/x4/directive/raw.hpp
+++ b/include/boost/spirit/x4/directive/raw.hpp
@@ -45,16 +45,16 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             // never noexcept; construction of `std::ranges::subrange` is never noexcept
         {
-            static_assert(Parsable<Subject, It, Se, Context, RContext, unused_type>);
+            static_assert(Parsable<Subject, It, Se, Context, unused_type>);
 
             x4::skip_over(first, last, context);
             It local_it = first;
-            if (this->subject.parse(local_it, last, context, rcontext, unused))
+            if (this->subject.parse(local_it, last, context, unused))
             {
                 x4::move_to(first, local_it, attr);
                 first = local_it;
@@ -63,12 +63,12 @@ namespace boost::spirit::x4
             return false;
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, unused_type) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type>)
+        parse(It& first, Se const& last, Context const& context, unused_type) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, unused_type>)
         {
-            return this->subject.parse(first, last, context, rcontext, unused);
+            return this->subject.parse(first, last, context, unused);
         }
     };
 

--- a/include/boost/spirit/x4/directive/repeat.hpp
+++ b/include/boost/spirit/x4/directive/repeat.hpp
@@ -82,16 +82,16 @@ namespace boost::spirit::x4
             , bounds_(std::forward<BoundsT>(bounds))
         {}
 
-        template<std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template<std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             // never noexcept (requires container insertion)
         {
             It local_it = first;
             typename Bounds::value_type i{};
             for (; !bounds_.got_min(i); ++i)
             {
-                if (!detail::parse_into_container(this->subject, local_it, last, context, rcontext, x4::assume_container(attr)))
+                if (!detail::parse_into_container(this->subject, local_it, last, context, x4::assume_container(attr)))
                 {
                     return false;
                 }
@@ -101,7 +101,7 @@ namespace boost::spirit::x4
             // parse some more up to the maximum specified
             for (; !bounds_.got_max(i); ++i)
             {
-                if (!detail::parse_into_container(this->subject, first, last, context, rcontext, x4::assume_container(attr)))
+                if (!detail::parse_into_container(this->subject, first, last, context, x4::assume_container(attr)))
                 {
                     break;
                 }

--- a/include/boost/spirit/x4/directive/seek.hpp
+++ b/include/boost/spirit/x4/directive/seek.hpp
@@ -37,13 +37,13 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
         {
             for (It current(first); ; ++current)
             {
-                if (this->subject.parse(current, last, context, rcontext, attr))
+                if (this->subject.parse(current, last, context, attr))
                 {
                     first = current;
                     return true;

--- a/include/boost/spirit/x4/directive/skip.hpp
+++ b/include/boost/spirit/x4/directive/skip.hpp
@@ -38,14 +38,14 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires has_skipper_v<Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute>)
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, Context, RContext, Attribute>);
-            return this->subject.parse(first, last, context, rcontext, attr);
+            static_assert(Parsable<Subject, It, Se, Context, Attribute>);
+            return this->subject.parse(first, last, context, attr);
         }
 
     private:
@@ -57,18 +57,18 @@ namespace boost::spirit::x4
         >;
 
     public:
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires (!has_skipper_v<Context>)
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             // never noexcept (requires expectation failure modification)
         {
-            static_assert(Parsable<Subject, It, Se, context_t<Context>, RContext, Attribute>);
+            static_assert(Parsable<Subject, It, Se, context_t<Context>, Attribute>);
 
             auto const& skipper = detail::get_unused_skipper(x4::get<skipper_tag>(context));
 
             auto const local_ctx = x4::make_context<skipper_tag>(skipper, context);
-            bool const r = this->subject.parse(first, last, local_ctx, rcontext, attr);
+            bool const r = this->subject.parse(first, last, local_ctx, attr);
 
             if (x4::has_expectation_failure(local_ctx))
             {
@@ -94,12 +94,12 @@ namespace boost::spirit::x4
             , skipper_(skipper)
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, unused_type const&, RContext& rcontext, Attribute& attr) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, x4::context<skipper_tag, Skipper>, RContext, Attribute>)
+        parse(It& first, Se const& last, unused_type const&, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, x4::context<skipper_tag, Skipper>, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, x4::context<skipper_tag, Skipper>, RContext, Attribute>);
+            static_assert(Parsable<Subject, It, Se, x4::context<skipper_tag, Skipper>, Attribute>);
 
             // It is perfectly fine to omit the expectation_failure context
             // even in non-throwing mode if and only if the skipper itself
@@ -121,16 +121,16 @@ namespace boost::spirit::x4
             // into our brand new skipper context, in contrast to the
             // repacking process done in `x4::skip_over`.
             return this->subject.parse(
-                first, last, x4::make_context<skipper_tag>(skipper_), rcontext, attr
+                first, last, x4::make_context<skipper_tag>(skipper_), attr
             );
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             // never noexcept (requires expectation failure modification)
         {
-            static_assert(Parsable<Subject, It, Se, x4::context<skipper_tag, Context>, RContext, Attribute>);
+            static_assert(Parsable<Subject, It, Se, x4::context<skipper_tag, Context>, Attribute>);
 
             static_assert(
                 !std::is_same_v<expectation_failure_t<Context>, unused_type>,
@@ -142,7 +142,7 @@ namespace boost::spirit::x4
             // This logic is heavily related to the instantiation chain;
             // see `x4::skip_over` for details.
             auto const local_ctx = x4::make_context<skipper_tag>(skipper_, context);
-            bool const r = this->subject.parse(first, last, local_ctx, rcontext, attr);
+            bool const r = this->subject.parse(first, last, local_ctx, attr);
 
             if (x4::has_expectation_failure(local_ctx))
             {

--- a/include/boost/spirit/x4/directive/skip.hpp
+++ b/include/boost/spirit/x4/directive/skip.hpp
@@ -16,6 +16,7 @@
 #include <boost/spirit/x4/core/skip_over.hpp>
 #include <boost/spirit/x4/core/parser.hpp>
 
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -44,15 +45,16 @@ namespace boost::spirit::x4
         parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, Context, Attribute>);
             return this->subject.parse(first, last, context, attr);
         }
 
     private:
         template <typename Context>
-        using context_t = x4::context<
+        using context_t = context<
             skipper_tag,
-            decltype(detail::get_unused_skipper(x4::get<skipper_tag>(std::declval<Context const&>()))),
+            std::remove_cvref_t<decltype(detail::get_unused_skipper(
+                std::declval<get_context_plain_t<skipper_tag, Context> const&>()
+            ))>,
             Context
         >;
 
@@ -61,21 +63,12 @@ namespace boost::spirit::x4
             requires (!has_skipper_v<Context>)
         [[nodiscard]] constexpr bool
         parse(It& first, Se const& last, Context const& context, Attribute& attr) const
-            // never noexcept (requires expectation failure modification)
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, context_t<Context>, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, context_t<Context>, Attribute>);
-
+            // This logic is heavily related to the instantiation chain;
+            // see `x4::skip_over` for details.
             auto const& skipper = detail::get_unused_skipper(x4::get<skipper_tag>(context));
-
-            auto const local_ctx = x4::make_context<skipper_tag>(skipper, context);
-            bool const r = this->subject.parse(first, last, local_ctx, attr);
-
-            if (x4::has_expectation_failure(local_ctx))
-            {
-                x4::set_expectation_failure(x4::get_expectation_failure(local_ctx), context);
-            }
-
-            return r;
+            return this->subject.parse(first, last, x4::make_context<skipper_tag>(skipper, context), attr);
         }
     };
 
@@ -91,49 +84,16 @@ namespace boost::spirit::x4
         constexpr skip_directive(SubjectT&& subject, SkipperT&& skipper)
             noexcept(std::is_nothrow_constructible_v<base_type, SubjectT> && std::is_nothrow_constructible_v<Skipper, SkipperT>)
             : base_type(std::forward<SubjectT>(subject))
-            , skipper_(skipper)
+            , skipper_(std::forward<SkipperT>(skipper))
         {}
-
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
-        [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, unused_type const&, Attribute& attr) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, x4::context<skipper_tag, Skipper>, Attribute>)
-        {
-            static_assert(Parsable<Subject, It, Se, x4::context<skipper_tag, Skipper>, Attribute>);
-
-            // It is perfectly fine to omit the expectation_failure context
-            // even in non-throwing mode if and only if the skipper itself
-            // is expectation-less.
-            //
-            // For example:
-            //   skip(a > b) [lit('foo')]
-            //   skip(c >> d)[lit('foo')]
-            //     `a > b`  should require non-`unused_type` context, but
-            //     `c >> d` should NOT require non-`unused_type` context
-            //
-            // However, it's impossible right now to detect whether
-            // `this->subject` actually is expectation-less, so we just
-            // call the parse function to see what will happen. If the
-            // subject turns out to lack the expectation context,
-            // static_assert will be engaged in other locations.
-            //
-            // Anyways, we don't need to repack the expectation context
-            // into our brand new skipper context, in contrast to the
-            // repacking process done in `x4::skip_over`.
-            return this->subject.parse(
-                first, last, x4::make_context<skipper_tag>(skipper_), attr
-            );
-        }
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
         parse(It& first, Se const& last, Context const& context, Attribute& attr) const
-            // never noexcept (requires expectation failure modification)
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, x4::context<skipper_tag, Skipper, Context>, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, x4::context<skipper_tag, Context>, Attribute>);
-
             static_assert(
-                !std::is_same_v<expectation_failure_t<Context>, unused_type>,
+                !std::same_as<expectation_failure_t<Context>, unused_type>,
                 "Context type was not specified for x4::expectation_failure_tag. "
                 "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
                 "Note that you must also bind the context to your skipper."
@@ -141,14 +101,7 @@ namespace boost::spirit::x4
 
             // This logic is heavily related to the instantiation chain;
             // see `x4::skip_over` for details.
-            auto const local_ctx = x4::make_context<skipper_tag>(skipper_, context);
-            bool const r = this->subject.parse(first, last, local_ctx, attr);
-
-            if (x4::has_expectation_failure(local_ctx))
-            {
-                x4::set_expectation_failure(x4::get_expectation_failure(local_ctx), context);
-            }
-            return r;
+            return this->subject.parse(first, last, x4::make_context<skipper_tag>(skipper_, context), attr);
         }
 
     private:
@@ -168,7 +121,7 @@ namespace boost::spirit::x4
             >;
 
             template <typename SkipperT>
-                requires std::is_same_v<std::remove_cvref_t<SkipperT>, std::remove_cvref_t<Skipper>>
+                requires std::same_as<std::remove_cvref_t<SkipperT>, std::remove_cvref_t<Skipper>>
             constexpr skip_gen_impl(SkipperT&& skipper)
                 noexcept(std::is_nothrow_constructible_v<skipper_type, SkipperT>)
                 : skipper_(std::forward<SkipperT>(skipper))
@@ -190,7 +143,7 @@ namespace boost::spirit::x4
             }
 
         private:
-            skipper_type skipper_;
+            skipper_type skipper_;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
         };
 
         struct skip_gen

--- a/include/boost/spirit/x4/directive/with.hpp
+++ b/include/boost/spirit/x4/directive/with.hpp
@@ -120,16 +120,16 @@ namespace boost::spirit::x4
         template <typename Context>
         using context_t = context<ID, std::remove_reference_t<T>, Context>;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, context_t<Context>, RContext, Attribute>)
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, context_t<Context>, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, context_t<Context>, RContext, Attribute>);
+            static_assert(Parsable<Subject, It, Se, context_t<Context>, Attribute>);
             return this->subject.parse(
                 first, last,
                 x4::make_context<ID>(this->val_, context),
-                rcontext, attr
+                attr
             );
         }
 

--- a/include/boost/spirit/x4/numeric/bool.hpp
+++ b/include/boost/spirit/x4/numeric/bool.hpp
@@ -75,9 +75,9 @@ namespace boost::spirit::x4
         	: policies_(std::forward<BoolPoliciesT>(policies))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, T& attr) const
+        parse(It& first, Se const& last, Context const& context, T& attr) const
             // TODO: noexcet
         {
             x4::skip_over(first, last, context);
@@ -85,14 +85,14 @@ namespace boost::spirit::x4
                 || policies_.parse_false(first, last, attr, get_case_compare<encoding>(context));
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute& attr_param) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr_param) const
             // TODO: noexcept
         {
             // this case is called when Attribute is not T
             T attr_;
-            if (bool_parser::parse(first, last, context, unused, attr_))
+            if (bool_parser::parse(first, last, context, attr_))
             {
                 x4::move_to(std::move(attr_), attr_param);
                 return true;
@@ -132,9 +132,9 @@ namespace boost::spirit::x4
             , n_(std::forward<Value>(n))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, T& attr) const
+        parse(It& first, Se const& last, Context const& context, T& attr) const
             // TODO: noexcept
         {
             x4::skip_over(first, last, context);
@@ -142,14 +142,14 @@ namespace boost::spirit::x4
                 || (!n_ && policies_.parse_false(first, last, attr, x4::get_case_compare<encoding>(context)));
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const& rcontext, Attribute& attr_param) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr_param) const
             // TODO: noexcept
         {
             // this case is called when Attribute is not T
             T attr_;
-            if (literal_bool_parser::parse(first, last, context, rcontext, attr_))
+            if (literal_bool_parser::parse(first, last, context, attr_))
             {
                 x4::move_to(std::move(attr_), attr_param);
                 return true;

--- a/include/boost/spirit/x4/numeric/int.hpp
+++ b/include/boost/spirit/x4/numeric/int.hpp
@@ -35,15 +35,13 @@ namespace boost::spirit::x4
         using attribute_type = T;
         static constexpr bool has_attribute = true;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(
-            It& first, Se const& last,
-            Context const& context, RContext const&, Attribute& attr
-        ) const noexcept(
-            noexcept(x4::skip_over(first, last, context)) &&
-            noexcept(extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
-        )
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(
+                noexcept(x4::skip_over(first, last, context)) &&
+                noexcept(extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
+            )
         {
             x4::skip_over(first, last, context);
             return extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr);

--- a/include/boost/spirit/x4/numeric/real.hpp
+++ b/include/boost/spirit/x4/numeric/real.hpp
@@ -199,33 +199,30 @@ namespace boost::spirit::x4
             : policies_(std::forward<RealPoliciesT>(policies))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(
-            It& first, Se const& last,
-            Context const& context, RContext const&, T& attr_
-        ) const noexcept(
-            noexcept(x4::skip_over(first, last, context)) &&
-            noexcept(extract_real<T, RealPolicies>::parse(first, last, attr_, policies_))
-        )
+        parse(It& first, Se const& last, Context const& context, T& attr_) const
+            noexcept(
+                noexcept(x4::skip_over(first, last, context)) &&
+                noexcept(extract_real<T, RealPolicies>::parse(first, last, attr_, policies_))
+            )
         {
             x4::skip_over(first, last, context);
             return extract_real<T, RealPolicies>::parse(first, last, attr_, policies_);
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last,
-            Context const& context, RContext const&, Attribute& attr_param
-        ) const noexcept(
-            std::is_nothrow_default_constructible_v<T> &&
-            noexcept(this->parse(first, last, context, unused, std::declval<T&>())) &&
-            noexcept(x4::move_to(std::declval<T&&>(), attr_param))
-        )
+        parse(It& first, Se const& last, Context const& context, Attribute& attr_param) const
+            noexcept(
+                std::is_nothrow_default_constructible_v<T> &&
+                noexcept(this->parse(first, last, context, std::declval<T&>())) &&
+                noexcept(x4::move_to(std::declval<T&&>(), attr_param))
+            )
         {
             // this case is called when Attribute is not T
             T attr_;
-            if (this->parse(first, last, context, unused, attr_))
+            if (this->parse(first, last, context, attr_))
             {
                 x4::move_to(std::move(attr_), attr_param);
                 return true;

--- a/include/boost/spirit/x4/numeric/uint.hpp
+++ b/include/boost/spirit/x4/numeric/uint.hpp
@@ -36,13 +36,11 @@ namespace boost::spirit::x4
 
         template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(
-            It& first, Se const& last,
-            Context const& context, unused_type, Attribute& attr
-        ) const noexcept(
-            noexcept(x4::skip_over(first, last, context)) &&
-            noexcept(extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
-        )
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(
+                noexcept(x4::skip_over(first, last, context)) &&
+                noexcept(extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
+            )
         {
             x4::skip_over(first, last, context);
             return extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr);

--- a/include/boost/spirit/x4/operator/alternative.hpp
+++ b/include/boost/spirit/x4/operator/alternative.hpp
@@ -36,30 +36,30 @@ namespace boost::spirit::x4
             : base_type(std::forward<LeftT>(left), std::forward<RightT>(right))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, unused_type) const
+        parse(It& first, Se const& last, Context const& context, unused_type) const
             noexcept(
-                is_nothrow_parsable_v<Left, It, Se, Context, RContext, unused_type> &&
-                is_nothrow_parsable_v<Right, It, Se, Context, RContext, unused_type>
+                is_nothrow_parsable_v<Left, It, Se, Context, unused_type> &&
+                is_nothrow_parsable_v<Right, It, Se, Context, unused_type>
             )
         {
-            return this->left.parse(first, last, context, rcontext, unused)
+            return this->left.parse(first, last, context, unused)
                 || (!x4::has_expectation_failure(context)
-                    && this->right.parse(first, last, context, rcontext, unused));
+                    && this->right.parse(first, last, context, unused));
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(
-                noexcept(detail::parse_alternative(this->left, first, last, context, rcontext, attr)) &&
-                noexcept(detail::parse_alternative(this->right, first, last, context, rcontext, attr))
+                noexcept(detail::parse_alternative(this->left, first, last, context, attr)) &&
+                noexcept(detail::parse_alternative(this->right, first, last, context, attr))
             )
         {
-            return detail::parse_alternative(this->left, first, last, context, rcontext, attr)
+            return detail::parse_alternative(this->left, first, last, context, attr)
                 || (!x4::has_expectation_failure(context)
-                    && detail::parse_alternative(this->right, first, last, context, rcontext, attr));
+                    && detail::parse_alternative(this->right, first, last, context, attr));
         }
     };
 

--- a/include/boost/spirit/x4/operator/and_predicate.hpp
+++ b/include/boost/spirit/x4/operator/and_predicate.hpp
@@ -34,16 +34,16 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& /*attr*/) const
+        parse(It& first, Se const& last, Context const& context, Attribute& /*attr*/) const
             noexcept(
                 std::is_nothrow_copy_assignable_v<It> &&
-                is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type>
+                is_nothrow_parsable_v<Subject, It, Se, Context, unused_type>
             )
         {
             It it = first;
-            return this->subject.parse(it, last, context, rcontext, unused);
+            return this->subject.parse(it, last, context, unused);
         }
     };
 

--- a/include/boost/spirit/x4/operator/difference.hpp
+++ b/include/boost/spirit/x4/operator/difference.hpp
@@ -35,13 +35,13 @@ namespace boost::spirit::x4
             : base_type(std::forward<LeftT>(left), std::forward<RightT>(right))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
         {
             // Try Right first
             It start = first;
-            if (this->right.parse(first, last, context, rcontext, unused))
+            if (this->right.parse(first, last, context, unused))
             {
                 // Right succeeds, we fail.
                 first = start;
@@ -60,7 +60,7 @@ namespace boost::spirit::x4
             }
 
             // Right fails, now try Left
-            return this->left.parse(first, last, context, rcontext, attr);
+            return this->left.parse(first, last, context, attr);
         }
     };
 

--- a/include/boost/spirit/x4/operator/kleene.hpp
+++ b/include/boost/spirit/x4/operator/kleene.hpp
@@ -40,12 +40,12 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(noexcept(detail::parse_into_container(this->subject, first, last, context, rcontext, x4::assume_container(attr))))
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(noexcept(detail::parse_into_container(this->subject, first, last, context, x4::assume_container(attr))))
         {
-            while (detail::parse_into_container(this->subject, first, last, context, rcontext, x4::assume_container(attr)))
+            while (detail::parse_into_container(this->subject, first, last, context, x4::assume_container(attr)))
                 /* loop */;
 
             return !x4::has_expectation_failure(context);

--- a/include/boost/spirit/x4/operator/list.hpp
+++ b/include/boost/spirit/x4/operator/list.hpp
@@ -39,25 +39,25 @@ namespace boost::spirit::x4
             : base_type(std::forward<LeftT>(left), std::forward<RightT>(right))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(
-                noexcept(detail::parse_into_container(this->left, first, last, context, rcontext, x4::assume_container(attr))) &&
+                noexcept(detail::parse_into_container(this->left, first, last, context, x4::assume_container(attr))) &&
                 std::is_nothrow_copy_assignable_v<It> &&
-                is_nothrow_parsable_v<Right, It, Se, Context, RContext, unused_type>
+                is_nothrow_parsable_v<Right, It, Se, Context, unused_type>
             )
         {
             // In order to succeed we need to match at least one element
-            if (!detail::parse_into_container(this->left, first, last, context, rcontext, x4::assume_container(attr)))
+            if (!detail::parse_into_container(this->left, first, last, context, x4::assume_container(attr)))
             {
                 return false;
             }
 
             It last_parse_it = first;
             while (
-                this->right.parse(last_parse_it, last, context, rcontext, unused) &&
-                detail::parse_into_container(this->left, last_parse_it, last, context, rcontext, x4::assume_container(attr))
+                this->right.parse(last_parse_it, last, context, unused) &&
+                detail::parse_into_container(this->left, last_parse_it, last, context, x4::assume_container(attr))
             )
             {
                 // TODO: can we reduce this copy assignment?

--- a/include/boost/spirit/x4/operator/not_predicate.hpp
+++ b/include/boost/spirit/x4/operator/not_predicate.hpp
@@ -36,16 +36,16 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& /*attr*/) const
+        parse(It& first, Se const& last, Context const& context, Attribute& /*attr*/) const
             noexcept(
                 std::is_nothrow_copy_assignable_v<It> &&
-                is_nothrow_parsable_v<Subject, It, Se, Context, RContext, unused_type>
+                is_nothrow_parsable_v<Subject, It, Se, Context, unused_type>
             )
         {
             It local_first = first;
-            return !this->subject.parse(local_first, last, context, rcontext, unused)
+            return !this->subject.parse(local_first, last, context, unused)
                 && !has_expectation_failure(context);
         }
     };

--- a/include/boost/spirit/x4/operator/optional.hpp
+++ b/include/boost/spirit/x4/operator/optional.hpp
@@ -44,54 +44,51 @@ namespace boost::spirit::x4
 
         // catch-all overload
         template <
-            std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext,
-            typename Attribute // unconstrained
+            std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute // unconstrained
         >
         [[nodiscard]] constexpr bool
         parse(
-            It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr
+            It& first, Se const& last, Context const& context, Attribute& attr
         ) const
-            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, RContext, Attribute>)
+            noexcept(is_nothrow_parsable_v<Subject, It, Se, Context, Attribute>)
         {
-            static_assert(Parsable<Subject, It, Se, Context, RContext, Attribute>);
+            static_assert(Parsable<Subject, It, Se, Context, Attribute>);
 
             // discard [[nodiscard]]
-            (void)this->subject.parse(first, last, context, rcontext, attr);
+            (void)this->subject.parse(first, last, context, attr);
             return !x4::has_expectation_failure(context);
         }
 
         // container attribute
         template <
-            std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext,
-            traits::CategorizedAttr<traits::container_attribute> Attribute
+            std::forward_iterator It, std::sentinel_for<It> Se, typename Context, traits::CategorizedAttr<traits::container_attribute> Attribute
         >
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(noexcept(detail::parse_into_container(this->subject, first, last, context, rcontext, attr)))
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(noexcept(detail::parse_into_container(this->subject, first, last, context, attr)))
         {
             // discard [[nodiscard]]
-            (void)detail::parse_into_container(this->subject, first, last, context, rcontext, attr);
+            (void)detail::parse_into_container(this->subject, first, last, context, attr);
             return !x4::has_expectation_failure(context);
         }
 
         // optional attribute
         template <
-            std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext,
-            traits::CategorizedAttr<traits::optional_attribute> Attribute
+            std::forward_iterator It, std::sentinel_for<It> Se, typename Context, traits::CategorizedAttr<traits::optional_attribute> Attribute
         >
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(
                 std::is_nothrow_default_constructible_v<x4::traits::optional_value_t<Attribute>> &&
-                is_nothrow_parsable_v<Subject, It, Se, Context, RContext, x4::traits::optional_value_t<Attribute>> &&
+                is_nothrow_parsable_v<Subject, It, Se, Context, x4::traits::optional_value_t<Attribute>> &&
                 noexcept(x4::move_to(std::declval<x4::traits::optional_value_t<Attribute>&&>(), attr))
             )
         {
             using value_type = x4::traits::optional_value_t<Attribute>;
             value_type val; // default-initialize
 
-            static_assert(Parsable<Subject, It, Se, Context, RContext, value_type>);
-            if (this->subject.parse(first, last, context, rcontext, val))
+            static_assert(Parsable<Subject, It, Se, Context, value_type>);
+            if (this->subject.parse(first, last, context, val))
             {
                 // assign the parsed value into our attribute
                 x4::move_to(std::move(val), attr);

--- a/include/boost/spirit/x4/operator/plus.hpp
+++ b/include/boost/spirit/x4/operator/plus.hpp
@@ -41,17 +41,17 @@ namespace boost::spirit::x4
             : base_type(std::forward<SubjectT>(subject))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(noexcept(detail::parse_into_container(this->subject, first, last, context, rcontext, x4::assume_container(attr))))
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(noexcept(detail::parse_into_container(this->subject, first, last, context, x4::assume_container(attr))))
         {
-            if (!detail::parse_into_container(this->subject, first, last, context, rcontext, x4::assume_container(attr)))
+            if (!detail::parse_into_container(this->subject, first, last, context, x4::assume_container(attr)))
             {
                 return false;
             }
 
-            while (detail::parse_into_container(this->subject, first, last, context, rcontext, x4::assume_container(attr)))
+            while (detail::parse_into_container(this->subject, first, last, context, x4::assume_container(attr)))
                 /* loop */;
 
             return !x4::has_expectation_failure(context);

--- a/include/boost/spirit/x4/operator/sequence.hpp
+++ b/include/boost/spirit/x4/operator/sequence.hpp
@@ -38,19 +38,19 @@ namespace boost::spirit::x4
             : base_type(std::forward<LeftT>(left), std::forward<RightT>(right))
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, unused_type) const
+        parse(It& first, Se const& last, Context const& context, unused_type) const
             noexcept(
                 std::is_nothrow_copy_assignable_v<It> &&
-                is_nothrow_parsable_v<Left, It, Se, Context, RContext, unused_type> &&
-                is_nothrow_parsable_v<Right, It, Se, Context, RContext, unused_type>
+                is_nothrow_parsable_v<Left, It, Se, Context, unused_type> &&
+                is_nothrow_parsable_v<Right, It, Se, Context, unused_type>
             )
         {
             It const first_saved = first;
 
-            if (this->left.parse(first, last, context, rcontext, unused)
-                && this->right.parse(first, last, context, rcontext, unused))
+            if (this->left.parse(first, last, context, unused)
+                && this->right.parse(first, last, context, unused))
             {
                 return true;
             }
@@ -65,13 +65,13 @@ namespace boost::spirit::x4
             return false;
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
             requires (!std::is_same_v<std::remove_const_t<Attribute>, unused_type>)
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext& rcontext, Attribute& attr) const
-            noexcept(noexcept(detail::parse_sequence(*this, first, last, context, rcontext, attr)))
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
+            noexcept(noexcept(detail::parse_sequence(*this, first, last, context, attr)))
         {
-            return detail::parse_sequence(*this, first, last, context, rcontext, attr);
+            return detail::parse_sequence(*this, first, last, context, attr);
         }
     };
 

--- a/include/boost/spirit/x4/parse.hpp
+++ b/include/boost/spirit/x4/parse.hpp
@@ -20,7 +20,6 @@
 
 #include <boost/spirit/x4/parse_result.hpp>
 
-#include <optional>
 #include <iterator>
 #include <ranges>
 #include <string_view>
@@ -38,6 +37,61 @@ namespace boost::spirit::x4
     };
 
     using skip_flag [[deprecated("Use `root_skipper_flag`")]] = root_skipper_flag;
+
+    // --------------------------------------------
+    // Default parse context
+
+    namespace detail
+    {
+        template <typename ItOrRange>
+        struct parse_context_for_impl;
+
+        template <std::forward_iterator It>
+        struct parse_context_for_impl<It>
+        {
+            using type = context<
+                expectation_failure_tag,
+                expectation_failure<It>
+            >;
+        };
+
+        template <std::ranges::forward_range R>
+        struct parse_context_for_impl<R>
+            : parse_context_for_impl<std::ranges::iterator_t<R const>>
+        {};
+
+        template <typename Skipper, typename ItOrRange, typename SeOrRange = ItOrRange>
+        struct phrase_parse_context_for_impl;
+
+        template <typename Skipper, std::forward_iterator It, std::sentinel_for<It> Se>
+        struct phrase_parse_context_for_impl<Skipper, It, Se>
+        {
+            static_assert(X4ExplicitParser<Skipper, It, Se>);
+
+            using type = context<
+                expectation_failure_tag,
+                expectation_failure<It>,
+                context<skipper_tag, Skipper const>
+            >;
+        };
+
+        template <typename Skipper, std::ranges::forward_range R>
+        struct phrase_parse_context_for_impl<Skipper, R>
+            : phrase_parse_context_for_impl<Skipper, std::ranges::iterator_t<R const>, std::ranges::sentinel_t<R const>>
+        {};
+
+    } // detail
+
+    // Used for determining the context type required in `BOOST_SPIRIT_X4_INSTANTIATE`.
+    // Note that sentinel is not required, because only the iterator is needed for error info.
+    // We keep the empty parameter as the noop placeholder to make the interface consistent with `phrase_parse_context_for`.
+    template <typename ItOrRange, typename = void>
+    using parse_context_for = typename detail::parse_context_for_impl<ItOrRange>::type;
+
+    // Used for determining the context type required in `BOOST_SPIRIT_X4_INSTANTIATE`.
+    template <typename Skipper, typename ItOrRange, typename SeOrRange = ItOrRange>
+    using phrase_parse_context_for = typename detail::phrase_parse_context_for_impl<Skipper, ItOrRange, SeOrRange>::type;
+
 
     namespace detail
     {
@@ -60,17 +114,157 @@ namespace boost::spirit::x4
         struct parse_fn_main
         {
             // --------------------------------------------
+            // parse(range)
+
+            // R + Parser + Attribute
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+                requires (!traits::CharArray<R>)
+            static constexpr parse_result_for<R>
+            operator()(R const& range, Parser&& p, Attr& attr)
+            {
+                using It = std::ranges::iterator_t<R const>;
+                using Se = std::ranges::sentinel_t<R const>;
+
+                expectation_failure<It> expect_failure;
+
+                It first = std::ranges::begin(range);
+                Se last = std::ranges::end(range);
+                bool const ok = as_parser(std::forward<Parser>(p)).parse(
+                    first, last,
+                    x4::make_context<expectation_failure_tag>(expect_failure),
+                    attr
+                );
+                return parse_result_for<R>{
+                    .ok = ok,
+                    .expect_failure = std::move(expect_failure),
+                    .remainder = {std::move(first), std::move(last)}
+                };
+            }
+
+            // parse_result + R + Parser + Attribute
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+                requires (!traits::CharArray<R>)
+            static constexpr void
+            operator()(parse_result_for<R>& res, R const& range, Parser&& p, Attr& attr)
+            {
+                using It = std::ranges::iterator_t<R const>;
+                using Se = std::ranges::sentinel_t<R const>;
+                It first = std::ranges::begin(range);
+                Se last = std::ranges::end(range);
+
+                res.expect_failure.clear();
+                res.ok = as_parser(std::forward<Parser>(p)).parse(
+                    first, last,
+                    x4::make_context<expectation_failure_tag>(res.expect_failure),
+                    attr
+                );
+                res.remainder = {std::move(first), std::move(last)};
+            }
+
+            // "str" + Parser + Attribute
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+            static constexpr parse_result_for<R>
+            operator()(R const& str, Parser&& p, Attr& attr)
+            {
+                return parse_fn_main::operator()(std::basic_string_view{str}, std::forward<Parser>(p), attr);
+            }
+
+            // parse_result + "str" + Parser + Attribute
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+            static constexpr void
+            operator()(parse_result_for<R>& res, R const& str, Parser&& p, Attr& attr)
+            {
+                return parse_fn_main::operator()(res, std::basic_string_view{str}, std::forward<Parser>(p), attr);
+            }
+
+            // --------------------------------------------
+            // phrase_parse(range)
+
+            // R + Parser + Skipper + Attribute + (root_skipper_flag)
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+                requires (!traits::CharArray<R>)
+            static constexpr parse_result_for<R>
+            operator()(R const& range, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            {
+                using It = std::ranges::iterator_t<R const>;
+                using Se = std::ranges::sentinel_t<R const>;
+                It first = std::ranges::begin(range);
+                Se last = std::ranges::end(range);
+
+                auto const skipper_ctx = x4::make_context<skipper_tag>(s);
+
+                expectation_failure<It> expect_failure;
+                auto const ctx = x4::make_context<expectation_failure_tag>(expect_failure, skipper_ctx);
+
+                bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
+                if (ok && flag == root_skipper_flag::do_post_skip)
+                {
+                    x4::skip_over(first, last, ctx);
+                    // ReSharper disable once CppAssignedValueIsNeverUsed
+                    if (expect_failure) [[unlikely]] ok = false;
+                }
+                return parse_result_for<R>{
+                    .ok = ok,
+                    .expect_failure = std::move(expect_failure),
+                    .remainder = {std::move(first), std::move(last)}
+                };
+            }
+
+            // parse_result + R + Parser + Skipper + Attribute
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+                requires (!traits::CharArray<R>)
+            static constexpr void
+            operator()(parse_result_for<R>& res, R const& range, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            {
+                using It = std::ranges::iterator_t<R const>;
+                using Se = std::ranges::sentinel_t<R const>;
+                It first = std::ranges::begin(range);
+                Se last = std::ranges::end(range);
+
+                auto const skipper_ctx = x4::make_context<skipper_tag>(s);
+
+                res.expect_failure.clear();
+                auto const ctx = x4::make_context<expectation_failure_tag>(res.expect_failure, skipper_ctx);
+
+                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
+                if (res.ok && flag == root_skipper_flag::do_post_skip)
+                {
+                    x4::skip_over(first, last, ctx);
+                    if (res.expect_failure) [[unlikely]] res.ok = false;
+                }
+                res.remainder = {std::move(first), std::move(last)};
+            }
+
+            // "str" + Parser + Skipper + Attribute + (root_skipper_flag)
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+            static constexpr parse_result_for<R>
+            operator()(R const& str, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            {
+                return parse_fn_main::operator()(std::basic_string_view{str}, std::forward<Parser>(p), s, attr, flag);
+            }
+
+            // parse_result + "str" + Parser + Attribute + Skipper
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+            static constexpr void
+            operator()(parse_result_for<R>& res, R const& str, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            {
+                return parse_fn_main::operator()(res, std::basic_string_view{str}, std::forward<Parser>(p), s, attr, flag);
+            }
+
+            // --------------------------------------------
             // parse(it/se)
 
             // It/Se + Parser + Attribute
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4Attribute Attr>
             static constexpr parse_result<It, Se>
-            operator()(It first, Se last, Parser&& p, X4Attribute auto& attr)
+            operator()(It first, Se last, Parser&& p, Attr& attr)
             {
-                std::optional<expectation_failure<It>> expect_failure;
-                auto failure_ctx = x4::make_context<expectation_failure_tag>(expect_failure);
-
-                bool const ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
+                expectation_failure<It> expect_failure;
+                bool const ok = as_parser(std::forward<Parser>(p)).parse(
+                    first, last,
+                    x4::make_context<expectation_failure_tag>(expect_failure),
+                    attr
+                );
                 return parse_result<It, Se>{
                     .ok = ok,
                     .expect_failure = std::move(expect_failure),
@@ -79,88 +273,31 @@ namespace boost::spirit::x4
             }
 
             // parse_result + It/Se + Parser + Attribute
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4Attribute Attr>
             static constexpr void
-            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, X4Attribute auto& attr)
+            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, Attr& attr)
             {
-                res.expect_failure.reset();
-                auto failure_ctx = x4::make_context<expectation_failure_tag>(res.expect_failure);
-
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
+                res.expect_failure.clear();
+                res.ok = as_parser(std::forward<Parser>(p)).parse(
+                    first, last,
+                    x4::make_context<expectation_failure_tag>(res.expect_failure),
+                    attr
+                );
                 res.remainder = {std::move(first), std::move(last)};
-            }
-
-            // --------------------------------------------
-            // parse(range)
-
-            // R + Parser + Attribute
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser>
-                requires (!traits::CharArray<R>)
-            static constexpr parse_result_for<R>
-            operator()(R const& range, Parser&& p, X4Attribute auto& attr)
-            {
-                using It = std::ranges::iterator_t<R const>;
-                using Se = std::ranges::sentinel_t<R const>;
-
-                std::optional<expectation_failure<It>> expect_failure;
-                auto failure_ctx = x4::make_context<expectation_failure_tag>(expect_failure);
-
-                It first = std::ranges::begin(range);
-                Se last = std::ranges::end(range);
-                bool const ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
-                return parse_result_for<R>{
-                    .ok = ok,
-                    .expect_failure = std::move(expect_failure),
-                    .remainder = {std::move(first), std::move(last)}
-                };
-            }
-
-            // "str" + Parser + Attribute
-            template <traits::CharArray R, X4RangeParseParser<R> Parser>
-            static constexpr parse_result_for<R>
-            operator()(R const& str, Parser&& p, X4Attribute auto& attr)
-            {
-                return parse_fn_main::operator()(std::basic_string_view{str}, std::forward<Parser>(p), attr);
-            }
-
-            // parse_result + R + Parser + Attribute
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser>
-                requires (!traits::CharArray<R>)
-            static constexpr void
-            operator()(parse_result_for<R>& res, R const& range, Parser&& p, X4Attribute auto& attr)
-            {
-                using It = std::ranges::iterator_t<R const>;
-                using Se = std::ranges::sentinel_t<R const>;
-
-                res.expect_failure.reset();
-                auto failure_ctx = x4::make_context<expectation_failure_tag>(res.expect_failure);
-
-                It first = std::ranges::begin(range);
-                Se last = std::ranges::end(range);
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
-                res.remainder = {std::move(first), std::move(last)};
-            }
-
-            // parse_result + "str" + Parser + Attribute
-            template <traits::CharArray R, X4RangeParseParser<R> Parser>
-            static constexpr void
-            operator()(parse_result_for<R>& res, R const& str, Parser&& p, X4Attribute auto& attr)
-            {
-                return parse_fn_main::operator()(res, std::basic_string_view{str}, std::forward<Parser>(p), attr);
             }
 
             // --------------------------------------------
             // phrase_parse(it/se)
 
             // It/Se + Parser + Skipper + Attribute + (root_skipper_flag)
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper, X4Attribute Attr>
             static constexpr parse_result<It, Se>
-            operator()(It first, Se last, Parser&& p, X4Attribute auto& attr, Skipper const& s, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(It first, Se last, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
-                auto skipper_ctx = x4::make_context<skipper_tag>(s);
+                auto const skipper_ctx = x4::make_context<skipper_tag>(s);
 
-                std::optional<expectation_failure<It>> expect_failure;
-                auto ctx = x4::make_context<expectation_failure_tag>(expect_failure, skipper_ctx);
+                expectation_failure<It> expect_failure;
+                auto const ctx = x4::make_context<expectation_failure_tag>(expect_failure, skipper_ctx);
 
                 bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
                 if (ok && flag == root_skipper_flag::do_post_skip)
@@ -177,14 +314,14 @@ namespace boost::spirit::x4
             }
 
             // parse_result + It/Se + Parser + Skipper + Attribute + (root_skipper_flag)
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper, X4Attribute Attr>
             static constexpr void
-            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, X4Attribute auto& attr, Skipper const& s, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
-                auto skipper_ctx = x4::make_context<skipper_tag>(s);
+                auto const skipper_ctx = x4::make_context<skipper_tag>(s);
 
-                res.expect_failure.reset();
-                auto ctx = x4::make_context<expectation_failure_tag>(res.expect_failure, skipper_ctx);
+                res.expect_failure.clear();
+                auto const ctx = x4::make_context<expectation_failure_tag>(res.expect_failure, skipper_ctx);
 
                 res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
                 if (res.ok && flag == root_skipper_flag::do_post_skip)
@@ -195,87 +332,12 @@ namespace boost::spirit::x4
                 res.remainder = {std::move(first), std::move(last)};
             }
 
-            // --------------------------------------------
-            // phrase_parse(range)
-
-            // R + Parser + Attribute + Skipper + (root_skipper_flag)
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper>
-                requires (!traits::CharArray<R>)
-            static constexpr parse_result_for<R>
-            operator()(R const& range, Parser&& p, X4Attribute auto& attr, Skipper const& s, root_skipper_flag flag = root_skipper_flag::do_post_skip)
-            {
-                using It = std::ranges::iterator_t<R const>;
-                using Se = std::ranges::sentinel_t<R const>;
-
-                auto skipper_ctx = x4::make_context<skipper_tag>(s);
-
-                std::optional<expectation_failure<It>> expect_failure;
-                auto ctx = x4::make_context<expectation_failure_tag>(expect_failure, skipper_ctx);
-
-                It first = std::ranges::begin(range);
-                Se last = std::ranges::end(range);
-                bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
-                if (ok && flag == root_skipper_flag::do_post_skip)
-                {
-                    x4::skip_over(first, last, ctx);
-                    // ReSharper disable once CppAssignedValueIsNeverUsed
-                    if (expect_failure) [[unlikely]] ok = false;
-                }
-                return parse_result_for<R>{
-                    .ok = ok,
-                    .expect_failure = std::move(expect_failure),
-                    .remainder = {std::move(first), std::move(last)}
-                };
-            }
-
-            // "str" + Parser + Attribute + Skipper + (root_skipper_flag)
-            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper>
-            static constexpr parse_result_for<R>
-            operator()(R const& str, Parser&& p, X4Attribute auto& attr, Skipper const& s, root_skipper_flag flag = root_skipper_flag::do_post_skip)
-            {
-                return parse_fn_main::operator()(std::basic_string_view{str}, std::forward<Parser>(p), attr, s, flag);
-            }
-
-            // parse_result + R + Parser + Attribute + Skipper
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper>
-                requires (!traits::CharArray<R>)
-            static constexpr void
-            operator()(parse_result_for<R>& res, R const& range, Parser&& p, X4Attribute auto& attr, Skipper const& s, root_skipper_flag flag = root_skipper_flag::do_post_skip)
-            {
-                using It = std::ranges::iterator_t<R const>;
-                using Se = std::ranges::sentinel_t<R const>;
-
-                auto skipper_ctx = x4::make_context<skipper_tag>(s);
-
-                res.expect_failure.reset();
-                auto ctx = x4::make_context<expectation_failure_tag>(res.expect_failure, skipper_ctx);
-
-                It first = std::ranges::begin(range);
-                Se last = std::ranges::end(range);
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
-                if (res.ok && flag == root_skipper_flag::do_post_skip)
-                {
-                    x4::skip_over(first, last, ctx);
-                    if (res.expect_failure) [[unlikely]] res.ok = false;
-                }
-                res.remainder = {std::move(first), std::move(last)};
-            }
-
-            // parse_result + "str" + Parser + Attribute + Skipper
-            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper>
-            static constexpr void
-            operator()(parse_result_for<R>& res, R const& str, Parser&& p, X4Attribute auto& attr, Skipper const& s, root_skipper_flag flag = root_skipper_flag::do_post_skip)
-            {
-                return parse_fn_main::operator()(res, std::basic_string_view{str}, std::forward<Parser>(p), attr, s, flag);
-            }
         }; // parse_fn_main
 
-        struct parse_fn : parse_fn_main
+        struct parse_fn_deprecated
         {
-            using parse_fn_main::operator();
-
             // --------------------------------------------
-            // deprecated
+            // deprecated `parse`
 
             // It/Se + Parser
             template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser>
@@ -298,7 +360,7 @@ namespace boost::spirit::x4
             operator()(parse_result_for<R>&, R&&, Parser&&) = delete; // If you don't need Attribute, explicitly pass `x4::unused`.
 
             // ---------------------------------------------
-            // deprecated phrase_parse
+            // deprecated `phrase_parse`
 
             // It/Se + Parser + Skipper
             template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper>
@@ -319,8 +381,13 @@ namespace boost::spirit::x4
             template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper>
             static constexpr void
             operator()(parse_result_for<R>&, R&&, Parser&&, Skipper const&) = delete; // If you don't need Attribute, explicitly pass `x4::unused`.
+        };
 
-        }; // parse_fn
+        struct parse_fn : parse_fn_main, parse_fn_deprecated
+        {
+            using parse_fn_main::operator();
+            using parse_fn_deprecated::operator();
+        };
 
     } // detail
 
@@ -332,64 +399,6 @@ namespace boost::spirit::x4
         inline constexpr detail::parse_fn phrase_parse{};
 
     } // cpos
-
-    // --------------------------------------------
-    // context
-
-    namespace detail
-    {
-        template <typename Skipper, typename ItOrRange, typename SeOrRange = ItOrRange>
-        struct phrase_parse_context_for_impl;
-
-        template <typename Skipper, std::forward_iterator It, std::sentinel_for<It> Se>
-        struct phrase_parse_context_for_impl<Skipper, It, Se>
-        {
-            static_assert(X4ExplicitParser<Skipper, It, Se>);
-
-            using type = context<
-                expectation_failure_tag,
-                std::optional<expectation_failure<It>>,
-                context<skipper_tag, Skipper const>
-            >;
-        };
-
-        template <typename Skipper, std::ranges::forward_range R>
-        struct phrase_parse_context_for_impl<Skipper, R>
-            : phrase_parse_context_for_impl<Skipper, std::ranges::iterator_t<R const>, std::ranges::sentinel_t<R const>>
-        {};
-
-    } // detail
-
-    // Used for determining the context type required in `BOOST_SPIRIT_X4_INSTANTIATE`.
-    template <typename Skipper, typename ItOrRange, typename SeOrRange = ItOrRange>
-    using phrase_parse_context_for = typename detail::phrase_parse_context_for_impl<Skipper, ItOrRange, SeOrRange>::type;
-
-    namespace detail
-    {
-        template <typename ItOrRange>
-        struct parse_context_for_impl;
-
-        template <std::forward_iterator It>
-        struct parse_context_for_impl<It>
-        {
-            using type = context<
-                expectation_failure_tag,
-                std::optional<expectation_failure<It>>
-            >;
-        };
-
-        template <std::ranges::forward_range R>
-        struct parse_context_for_impl<R>
-            : parse_context_for_impl<std::ranges::iterator_t<R const>>
-        {};
-
-    } // detail
-
-    // Used for determining the context type required in `BOOST_SPIRIT_X4_INSTANTIATE`.
-    // Note that sentinel is not required, because only the iterator is needed for error info.
-    // We keep the empty parameter as the noop placeholder to make the interface consistent with `phrase_parse_context_for`.
-    template <typename ItOrRange, typename = void>
-    using parse_context_for = typename detail::parse_context_for_impl<ItOrRange>::type;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/parse.hpp
+++ b/include/boost/spirit/x4/parse.hpp
@@ -70,7 +70,7 @@ namespace boost::spirit::x4
                 std::optional<expectation_failure<It>> expect_failure;
                 auto failure_ctx = x4::make_context<expectation_failure_tag>(expect_failure);
 
-                bool const ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, unused, attr);
+                bool const ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
                 return parse_result<It, Se>{
                     .ok = ok,
                     .expect_failure = std::move(expect_failure),
@@ -86,7 +86,7 @@ namespace boost::spirit::x4
                 res.expect_failure.reset();
                 auto failure_ctx = x4::make_context<expectation_failure_tag>(res.expect_failure);
 
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, unused, attr);
+                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
                 res.remainder = {std::move(first), std::move(last)};
             }
 
@@ -107,7 +107,7 @@ namespace boost::spirit::x4
 
                 It first = std::ranges::begin(range);
                 Se last = std::ranges::end(range);
-                bool const ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, unused, attr);
+                bool const ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
                 return parse_result_for<R>{
                     .ok = ok,
                     .expect_failure = std::move(expect_failure),
@@ -137,7 +137,7 @@ namespace boost::spirit::x4
 
                 It first = std::ranges::begin(range);
                 Se last = std::ranges::end(range);
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, unused, attr);
+                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, failure_ctx, attr);
                 res.remainder = {std::move(first), std::move(last)};
             }
 
@@ -162,7 +162,7 @@ namespace boost::spirit::x4
                 std::optional<expectation_failure<It>> expect_failure;
                 auto ctx = x4::make_context<expectation_failure_tag>(expect_failure, skipper_ctx);
 
-                bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, unused, attr);
+                bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
                 if (ok && flag == root_skipper_flag::do_post_skip)
                 {
                     x4::skip_over(first, last, ctx);
@@ -186,7 +186,7 @@ namespace boost::spirit::x4
                 res.expect_failure.reset();
                 auto ctx = x4::make_context<expectation_failure_tag>(res.expect_failure, skipper_ctx);
 
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, unused, attr);
+                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
                 if (res.ok && flag == root_skipper_flag::do_post_skip)
                 {
                     x4::skip_over(first, last, ctx);
@@ -214,7 +214,7 @@ namespace boost::spirit::x4
 
                 It first = std::ranges::begin(range);
                 Se last = std::ranges::end(range);
-                bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, unused, attr);
+                bool ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
                 if (ok && flag == root_skipper_flag::do_post_skip)
                 {
                     x4::skip_over(first, last, ctx);
@@ -252,7 +252,7 @@ namespace boost::spirit::x4
 
                 It first = std::ranges::begin(range);
                 Se last = std::ranges::end(range);
-                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, unused, attr);
+                res.ok = as_parser(std::forward<Parser>(p)).parse(first, last, ctx, attr);
                 if (res.ok && flag == root_skipper_flag::do_post_skip)
                 {
                     x4::skip_over(first, last, ctx);
@@ -346,12 +346,11 @@ namespace boost::spirit::x4
         {
             static_assert(X4ExplicitParser<Skipper, It, Se>);
 
-            using skipper_ctx_type = decltype(x4::make_context<skipper_tag>(std::declval<Skipper const&>()));
-
-            using type = decltype(x4::make_context<expectation_failure_tag>(
-                std::declval<std::optional<expectation_failure<It>>&>(),
-                std::declval<skipper_ctx_type const&>()
-            ));
+            using type = context<
+                expectation_failure_tag,
+                std::optional<expectation_failure<It>>,
+                context<skipper_tag, Skipper const>
+            >;
         };
 
         template <typename Skipper, std::ranges::forward_range R>
@@ -373,9 +372,10 @@ namespace boost::spirit::x4
         template <std::forward_iterator It>
         struct parse_context_for_impl<It>
         {
-            using type = decltype(x4::make_context<expectation_failure_tag>(
-                std::declval<std::optional<expectation_failure<It>>&>()
-            ));
+            using type = context<
+                expectation_failure_tag,
+                std::optional<expectation_failure<It>>
+            >;
         };
 
         template <std::ranges::forward_range R>

--- a/include/boost/spirit/x4/parse_result.hpp
+++ b/include/boost/spirit/x4/parse_result.hpp
@@ -12,7 +12,6 @@
 #include <boost/spirit/x4/core/expectation.hpp>
 #include <boost/spirit/x4/traits/string_traits.hpp>
 
-#include <optional>
 #include <iterator>
 #include <ranges>
 #include <string_view>
@@ -34,7 +33,7 @@ namespace boost::spirit::x4
         // Has value if and only if `ok` is `false` and any of
         // the underlying parsers have encountered expectation
         // failure.
-        std::optional<expectation_failure<It>> expect_failure;
+        expectation_failure<It> expect_failure;
 
         // Represents the remaining subrange of the input, after
         // applications of all (partially) successful attempts on

--- a/include/boost/spirit/x4/rule.hpp
+++ b/include/boost/spirit/x4/rule.hpp
@@ -171,10 +171,10 @@ namespace boost::spirit::x4
                     if (x4::has_expectation_failure(context)) {
                         auto const& x = x4::get_expectation_failure(context);
                         static_assert(
-                            std::is_void_v<decltype(RuleID{}.on_error(std::as_const(first), std::as_const(last), *x, context))>,
+                            std::is_void_v<decltype(RuleID{}.on_error(std::as_const(first), std::as_const(last), x, context))>,
                             "error handler should not return a value"
                         );
-                        RuleID{}.on_error(std::as_const(first), std::as_const(last), *x, context);
+                        RuleID{}.on_error(std::as_const(first), std::as_const(last), x, context);
                         return false;
                     }
                     return false;

--- a/include/boost/spirit/x4/rule.hpp
+++ b/include/boost/spirit/x4/rule.hpp
@@ -347,7 +347,7 @@ namespace boost::spirit::x4
         constexpr rule(rule const& r) noexcept
             : name(r.name)
         {
-            // Assert that we are not copying an unitialized static rule. If
+            // Assert that we are not copying an uninitialized static rule. If
             // the static is in another TU, it may be initialized after we copy
             // it. If so, its name member will be nullptr.
             assert(r.name != nullptr && "uninitialized rule"); // static initialization order fiasco
@@ -382,11 +382,11 @@ namespace boost::spirit::x4
             // Note that this removal is possible only because the actual invocation of
             // `parse_rule` *ALWAYS* results in subsequent invocation of `call_rule_definition`,
             // which resets the `_val` context to the appropriate reference.
-            auto&& non_rule_specific_ctx = x4::remove_first_context<rule_val_context_tag>(context);
+            auto&& rule_agnostic_ctx = x4::remove_first_context<rule_val_context_tag>(context);
 
             // ADL
             using detail::parse_rule;
-            if (static_cast<bool>(parse_rule(detail::rule_id<RuleID>{}, first, last, non_rule_specific_ctx, transformed_attr))) {
+            if (static_cast<bool>(parse_rule(detail::rule_id<RuleID>{}, first, last, rule_agnostic_ctx, transformed_attr))) {
                 transform::post(exposed_attr, std::forward<transformed_type>(transformed_attr));
                 return true;
             }
@@ -402,11 +402,11 @@ namespace boost::spirit::x4
             attribute_type no_attr; // default-initialize
 
             // See the comments on the primary overload of `rule::parse(...)`
-            auto&& non_rule_specific_ctx = x4::remove_first_context<rule_val_context_tag>(context);
+            auto&& rule_agnostic_ctx = x4::remove_first_context<rule_val_context_tag>(context);
 
             // ADL
             using detail::parse_rule;
-            return static_cast<bool>(parse_rule(detail::rule_id<RuleID>{}, first, last, non_rule_specific_ctx, no_attr));
+            return static_cast<bool>(parse_rule(detail::rule_id<RuleID>{}, first, last, rule_agnostic_ctx, no_attr));
         }
 
         template <X4Subject RHS>
@@ -587,14 +587,9 @@ namespace boost::spirit::x4
     } // detail
 
 #define BOOST_SPIRIT_X4_INSTANTIATE_(rule_type, It, Se, Context) \
-    /* non-recursively invoked version */ \
-    template bool parse_rule< \
-        It, Se, \
-        Context \
-    >( \
+    template bool parse_rule<It, Se, Context>( \
         ::boost::spirit::x4::detail::rule_id<typename std::remove_cvref_t<rule_type>::id>, \
-        It&, Se const&,\
-        Context const&, /* non-recursively invoked context is the plain `Context` */ \
+        It&, Se const&, Context const&, \
         typename std::remove_cvref_t<rule_type>::attribute_type& \
     );
 

--- a/include/boost/spirit/x4/rule.hpp
+++ b/include/boost/spirit/x4/rule.hpp
@@ -19,302 +19,127 @@
 #include <boost/spirit/x4/traits/transform_attribute.hpp>
 
 #ifdef BOOST_SPIRIT_X4_DEBUG
-#include <boost/spirit/x4/debug/simple_trace.hpp>
+# include <boost/spirit/x4/debug/simple_trace.hpp>
 #endif
+
+#include <boost/spirit/x4/debug/detail/parse_callback.hpp>
 
 #include <boost/preprocessor/variadic/to_seq.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
 
-#include <boost/config/helper_macros.hpp>
-
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 #include <utility>
 
 #ifndef BOOST_SPIRIT_X4_NO_RTTI
-#include <typeinfo>
+# include <typeinfo>
 #endif
 
 #include <cassert>
 
 namespace boost::spirit::x4
 {
-    template <typename ID, typename Attribute = unused_type, bool force_attribute = false>
+    template <typename RuleID, typename Attribute = unused_type, bool ForceAttribute = false>
     struct rule;
 
     struct parse_pass_context_tag;
 
     namespace detail
     {
-        template <typename ID>
-        struct rule_id {};
+        template <typename RuleID>
+        struct rule_id
+        {
+            static_assert(UniqueContextID<RuleID>);
+        };
 
         // Placeholder type to detect whether the default `parse_rule(...)` is called
         enum struct default_parse_rule_result : bool {};
 
-        template <typename ID, typename Context>
-        constexpr bool context_has_rule_id = !std::is_same_v<
-            std::remove_cvref_t<decltype(x4::get<ID>(std::declval<Context const&>()))>,
-            unused_type
-        >;
-    } // detail
-
-    // The default `parse_rule` definition.
-    //
-    // This overload will only be selected when there exists no user-defined
-    // definition for `parse_rule`.
-    //
-    // When a user invokes `BOOST_SPIRIT_X4_DEFINE_`, an unconstrained overload
-    // is generated at the user's namespace scope. It will never conflict with
-    // this (vvvvv) overload, as the generated one is never directly called with
-    // a context containing `ID`.
-    template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
-        requires detail::context_has_rule_id<ID, Context>
-    [[nodiscard]] constexpr detail::default_parse_rule_result
-    parse_rule(
-        detail::rule_id<ID>,
-        It& first, Se const& last,
-        Context const& context, Attribute& attr
-    )
-    {
-        auto&& rule_ = x4::get<ID>(context);
-        return static_cast<detail::default_parse_rule_result>(
-            rule_.parse(first, last, context, unused, attr)
-        );
-    }
-
-    // This overload is selected only when the user *declares* their `parse_rule`
-    // in the user's namespace scope AND the function definition is not found.
-    template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
-        requires (!detail::context_has_rule_id<ID, Context>)
-    constexpr void
-    parse_rule(
-        detail::rule_id<ID>,
-        It&, Se const&,
-        Context const&, Attribute&
-    ) = delete; // BOOST_SPIRIT_X4_DEFINE undefined for this rule
-
-
-    namespace detail
-    {
-#ifdef BOOST_SPIRIT_X4_DEBUG
-        // TODO: This should be customizable by users
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute>
-        struct scoped_debug
+        // The default `parse_rule` definition.
+        //
+        // This overload will only be selected when there exists no user-defined
+        // definition for `parse_rule`.
+        //
+        // When a user invokes `BOOST_SPIRIT_X4_DEFINE_`, an unconstrained overload
+        // is generated at the user's namespace scope. It will never conflict with
+        // this (vvvvv) overload, as the generated one is never directly called with
+        // a context containing `RuleID`.
+        template <typename RuleID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
+            requires has_context_v<Context, RuleID>
+        [[nodiscard]] constexpr default_parse_rule_result
+        parse_rule(
+            rule_id<RuleID>,
+            It& first, Se const& last,
+            Context const& context, Attribute& attr
+        )
         {
-            scoped_debug(
-                char const* rule_name,
-                It const& first, Se const& last,
-                Attribute const& attr,
-                bool const* parse_ok
-            )
-                : parse_ok(parse_ok)
-                , rule_name(rule_name)
-                , first(first)
-                , last(last)
-                , attr(attr)
-                , f(detail::get_simple_trace())
-            {
-                f(first, last, attr, debug_handler_state::pre_parse, rule_name);
-            }
+            auto&& rule_ = x4::get<RuleID>(context);
 
-            ~scoped_debug()
-            {
-                f(
-                    first, last,
-                    attr,
-                    *parse_ok ? debug_handler_state::successful_parse : debug_handler_state::failed_parse,
-                    rule_name
-                );
-            }
-
-            bool const* parse_ok = nullptr;
-            char const* rule_name = nullptr;
-            It const& first;
-            Se const& last;
-            Attribute const& attr;
-            detail::simple_trace_type& f;
-        };
-#endif
-
-        template <typename ID, typename It, typename Se, typename Context>
-        concept HasImmutableOnErrorOverload =
-            std::forward_iterator<It> &&
-            std::sentinel_for<Se, It> &&
-            requires(ID& id) { // Note: `ID` should be non-const
-                id.on_error(
-                    std::declval<It const&>(),
-                    std::declval<Se const&>(),
-                    std::declval<expectation_failure<It> const&>(),
-                    std::declval<Context const&>()
-                );
-            };
-
-        template <typename ID, typename It, typename Se, typename Context>
-        concept HasMutableOnErrorOverload =
-            std::forward_iterator<It> &&
-            std::sentinel_for<Se, It> &&
-            requires(ID& id) { // Note: `ID` should be non-const
-                id.on_error(
-                    std::declval<It&>(),
-                    std::declval<Se&>(),
-                    std::declval<expectation_failure<It> const&>(),
-                    std::declval<Context const&>()
-                );
-            };
-
-        template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
-        struct has_on_error : std::false_type {};
-
-        template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
-            requires HasImmutableOnErrorOverload<ID, It, Se, Context>
-        struct has_on_error<ID, It, Se, Context> : std::true_type
-        {
-            // We intentionally make this hard error to prevent error-prone definition
-            static_assert(
-                std::is_void_v<
-                    decltype(std::declval<ID&>().on_error(
-                        std::declval<It const&>(),
-                        std::declval<Se const&>(),
-                        std::declval<expectation_failure<It> const&>(),
-                        std::declval<Context const&>()
-                    ))
-                >,
-                "The return type of `on_error` should be `void`."
+            return static_cast<default_parse_rule_result>(
+                rule_.parse(first, last, context, attr)
             );
-        };
+        }
 
-        template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
-            requires
-                (!HasImmutableOnErrorOverload<ID, It, Se, Context>) &&
-                HasMutableOnErrorOverload<ID, It, Se, Context>
-        struct has_on_error<ID, It, Se, Context> : std::false_type
+        // This overload is selected only when the user *declares* their `parse_rule`
+        // in the user's namespace scope AND the function definition is not found.
+        template <typename RuleID, std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
+            requires (!has_context_v<Context, RuleID>)
+        constexpr void
+        parse_rule(rule_id<RuleID>, It&, Se const&, Context const&, Attribute&)
+            = delete; // BOOST_SPIRIT_X4_DEFINE undefined for this rule
+
+
+        template <typename Attribute, typename RuleID, bool SkipDefinitionInjection = false>
+        struct rule_impl
         {
-            // Historically, Spirit has passed mutable lvalue references of the iterators *as-is*
-            // to the `on_success`/`on_error` handlers. This behavior was simply a mistake, because:
-            //   (1) `on_success`/`on_error` mechanism was designed to be grammar-agnostic, and
-            //   (2) it does not make sense to modify the grammar-specific iterator on the
-            //       grammar-agnostic callback.
-            //
-            // Furthermore, any modification to X4's internal iterator variables may invoke
-            // undefined behavior, since we never provide any kind of guarantee on how the
-            // intermediate iterator variables are processed in X4's implementation details.
-            static_assert(
-                false,
-                "The `on_error` callback should only accept const reference or passed-by-value iterators."
-            );
-        };
+            static_assert(UniqueContextID<RuleID>);
 
-        template <typename ID, typename It, typename Se, typename Attribute, typename Context>
-        concept HasImmutableOnSuccessOverload =
-            std::forward_iterator<It> &&
-            std::sentinel_for<Se, It> &&
-            requires(ID& id) { // Note: `ID` should be non-const
-                id.on_success(
-                    std::declval<It const&>(),
-                    std::declval<Se const&>(),
-                    std::declval<Attribute&>(),
-                    std::declval<Context const&>()
-                );
-            };
-
-        template <typename ID, typename It, typename Se, typename Attribute, typename Context>
-        concept HasMutableOnSuccessOverload =
-            std::forward_iterator<It> &&
-            std::sentinel_for<Se, It> &&
-            requires(ID& id) { // Note: `ID` should be non-const
-                id.on_success(
-                    std::declval<It&>(),
-                    std::declval<Se&>(),
-                    std::declval<Attribute&>(),
-                    std::declval<Context const&>()
-                );
-            };
-
-        template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute, typename Context>
-        struct has_on_success : std::false_type {};
-
-        template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute, typename Context>
-            requires HasImmutableOnSuccessOverload<ID, It, Se, Attribute, Context>
-        struct has_on_success<ID, It, Se, Attribute, Context> : std::true_type
-        {
-            // We intentionally make this hard error to prevent error-prone definition
-            static_assert(
-                std::is_void_v<
-                    decltype(std::declval<ID&>().on_success(
-                        std::declval<It const&>(),
-                        std::declval<Se const&>(),
-                        std::declval<Attribute&>(),
-                        std::declval<Context const&>()
-                    ))
-                >,
-                "The return type of `on_success` should be `void`."
-            );
-        };
-
-        template <typename ID, std::forward_iterator It, std::sentinel_for<It> Se, typename Attribute, typename Context>
-            requires
-                (!HasImmutableOnSuccessOverload<ID, It, Se, Attribute, Context>) &&
-                HasMutableOnSuccessOverload<ID, It, Se, Attribute, Context>
-        struct has_on_success<ID, It, Se, Attribute, Context> : std::false_type
-        {
-            // For details, see the comments on `has_on_error`.
-            static_assert(
-                false,
-                "The `on_success` callback should only accept const reference or passed-by-value iterators."
-            );
-        };
-
-        template <typename Attribute, typename ID, bool SkipDefinitionInjection = false>
-        struct rule_parser
-        {
             template <
                 typename RHS, std::forward_iterator It, std::sentinel_for<It> Se,
-                typename Context, typename RContext, typename Exposed
+                typename Context, typename Exposed
             >
             [[nodiscard]] static constexpr bool
             parse_rhs(
                 RHS const& rhs, It& first, Se const& last,
-                Context const& context, RContext& rcontext, Exposed& attr
+                Context const& context, Exposed& attr
             ) // never noexcept; requires complex handling
             {
-                It start = first;
-
-                // See if the user has a BOOST_SPIRIT_X4_DEFINE for this rule
-                using parse_rule_result_type = decltype(
-                    parse_rule( // ADL
-                        std::declval<detail::rule_id<ID>>(), first, last,
-                        std::declval<decltype(x4::make_unique_context<ID>(rhs, context))>(),
+                // See if the user has `BOOST_SPIRIT_X4_DEFINE` for this rule
+                constexpr bool is_default_parse_rule = std::same_as<
+                    decltype(parse_rule( // ADL
+                        std::declval<rule_id<RuleID>>(), first, last,
+                        std::declval<decltype(x4::make_context<RuleID>(rhs, context))>(),
                         std::declval<Attribute&>()
-                    )
-                );
-                constexpr bool is_default_parse_rule = std::is_same_v<
-                    parse_rule_result_type, default_parse_rule_result
+                    )),
+                    default_parse_rule_result
                 >;
+
+                It start = first; // backup
 
                 bool ok;
                 if constexpr (SkipDefinitionInjection || !is_default_parse_rule)
                 {
-                    ok = rhs.parse(first, last, context, rcontext, attr);
+                    ok = rhs.parse(first, last, context, attr);
                 }
                 else
                 {
-                    // If there is no BOOST_SPIRIT_X4_DEFINE for this rule,
-                    // we'll make a context for this rule tagged by its ID
+                    // If there is no `BOOST_SPIRIT_X4_DEFINE` for this rule,
+                    // we'll make a context for this rule tagged by its `RuleID`
                     // so we can extract the rule later on in the default
-                    // parse_rule function.
-                    auto rule_id_context = x4::make_unique_context<ID>(rhs, context);
-                    ok = rhs.parse(first, last, rule_id_context, rcontext, attr);
+                    // `parse_rule` overload.
+                    auto rule_id_context = x4::make_context<RuleID>(rhs, context);
+                    ok = rhs.parse(first, last, rule_id_context, attr);
                 }
 
                 // Note: this check uses `It, It` because the value is actually iterator-iterator pair
-                if constexpr (has_on_success<ID, It, It, Exposed, Context>::value)
+                if constexpr (has_on_success<RuleID, It, It, Exposed, Context>::value)
                 {
                     if (!ok) return false;
 
                     x4::skip_over(start, first, context);
                     bool pass = true;
-                    ID().on_success(
+                    RuleID{}.on_success(
                         std::as_const(start), std::as_const(first), attr,
                         x4::make_context<parse_pass_context_tag>(pass, context)
                     );
@@ -328,17 +153,17 @@ namespace boost::spirit::x4
 
             template <
                 typename RHS, std::forward_iterator It, std::sentinel_for<It> Se,
-                typename Context, typename RContext, typename Exposed
+                typename Context, typename Exposed
             >
             [[nodiscard]] static constexpr bool
             parse_rhs_with_on_error(
                 RHS const& rhs, It& first, Se const& last,
-                Context const& context, RContext& rcontext, Exposed& attr
+                Context const& context, Exposed& attr
             ) // never noexcept; requires complex handling
             {
                 while (true)
                 {
-                    if (rule_parser::parse_rhs(rhs, first, last, context, rcontext, attr))
+                    if (rule_impl::parse_rhs(rhs, first, last, context, attr))
                     {
                         return true;
                     }
@@ -346,10 +171,10 @@ namespace boost::spirit::x4
                     if (x4::has_expectation_failure(context)) {
                         auto const& x = x4::get_expectation_failure(context);
                         static_assert(
-                            std::is_void_v<decltype(ID{}.on_error(std::as_const(first), std::as_const(last), *x, context))>,
+                            std::is_void_v<decltype(RuleID{}.on_error(std::as_const(first), std::as_const(last), *x, context))>,
                             "error handler should not return a value"
                         );
-                        ID{}.on_error(std::as_const(first), std::as_const(last), *x, context);
+                        RuleID{}.on_error(std::as_const(first), std::as_const(last), *x, context);
                         return false;
                     }
                     return false;
@@ -368,7 +193,7 @@ namespace boost::spirit::x4
                 Context const& context, Exposed& attr
             )
             {
-                // Do down-stream transformation, provides attribute for rhs parser
+                // Do down-stream transformation, provide attribute for `rhs` parser
                 using transform = traits::transform_attribute<Attribute, Exposed>;
                 using transform_attr = typename transform::type;
                 transform_attr attr_ = transform::pre(attr);
@@ -380,26 +205,38 @@ namespace boost::spirit::x4
                 #ifdef BOOST_SPIRIT_X4_DEBUG
                     parse_ok = false;
 
-                    // Create a scope to cause the dbg variable below (within
-                    // the #if...#endif) to call it's DTOR before any
-                    // modifications are made to the attribute, attr_ passed
-                    // to parse_rhs (such as might be done in
-                    // transform::post when, for example,
-                    // Exposed is a recursive variant).
-                    scoped_debug<It, Se, transform_attr>
+                    // Debug on destructor, i.e., before any modifications are made to the
+                    // attribute passed to `parse_rhs`. Note: the debug must be done before
+                    // `transform::post`, where some types do some modifications there;
+                    // for instance, if `Exposed` is a recursive variant.
+                    scoped_rule_debug<It, Se, transform_attr>
                     dbg(rule_name, first, last, attr_, &parse_ok);
                 #else
                     (void)rule_name;
                 #endif
 
-                    // In theory, these calls can be overloaded using tag dispatches.
-                    // However we should get over those legacy technique already, as they
-                    // lead to enormous amount of call stack, generating unreadable
-                    // compilation errors. Even when we have a single layer of tag dispatch,
-                    // we should generally avoid it because the "true_type/false_type"
-                    // argument placed at the very last param of the overload is virtually
-                    // indistinguishable in messages and has serious QoL issue in debuggers.
-                    constexpr bool rhs_has_on_error = has_on_error<ID, It, Se, Context>::value;
+                    // Replace or insert the `_val` context, while avoiding infinite instantiation on
+                    // recursive grammars.
+                    //
+                    // In pre-X4 codebase, this was done by passing the extraneous `rcontext` parameter
+                    // to every `.parse(...)` invocation on ALL parsers. We dropped that param on X4;
+                    // now we simply append the rule attribute reference to the `context`, as it can
+                    // essentially work as the global storage for any parsers.
+                    //
+                    // Although the `context` acts like the "global" storage, the actual lifetime of the
+                    // rule-specific attribute is managed by stack-like structure, similar to that of
+                    // `x4::locals`. Note that we don't actually use `x4::locals` here; we *already have*
+                    // the stack-like structure because a recursive grammar inherently creates the nested
+                    // invocation hierarchy, which ultimately does the same thing.
+                    //
+                    //   Dear valued user,
+                    //   You have discovered the deepest wizardry of X4...
+                    //   You win!!
+                    //
+                    auto rcontext = x4::replace_first_context<rule_val_context_tag>(context, attr_);
+                    using RContext = decltype(rcontext);
+
+                    constexpr bool rhs_has_on_error = has_on_error<RuleID, It, Se, RContext>::value;
 
                     // The existence of semantic action inhibits attribute materialization
                     // _unless_ it is explicitly required by the user (primarily via `%=`).
@@ -407,14 +244,14 @@ namespace boost::spirit::x4
                     {
                         if constexpr (rhs_has_on_error)
                         {
-                            parse_ok = rule_parser::parse_rhs_with_on_error(
-                                rhs, first, last, context, attr_ /* rcontext */, unused
+                            parse_ok = rule_impl::parse_rhs_with_on_error(
+                                rhs, first, last, rcontext, unused
                             );
                         }
                         else
                         {
-                            parse_ok = rule_parser::parse_rhs(
-                                rhs, first, last, context, attr_ /* rcontext */, unused
+                            parse_ok = rule_impl::parse_rhs(
+                                rhs, first, last, rcontext, unused
                             );
                         }
                     }
@@ -422,77 +259,80 @@ namespace boost::spirit::x4
                     {
                         if constexpr (rhs_has_on_error)
                         {
-                            parse_ok = rule_parser::parse_rhs_with_on_error(
-                                rhs, first, last, context, attr_ /* rcontext */, attr_
+                            parse_ok = rule_impl::parse_rhs_with_on_error(
+                                rhs, first, last, rcontext, attr_
                             );
                         }
                         else
                         {
-                            parse_ok = rule_parser::parse_rhs(
-                                rhs, first, last, context, attr_ /* rcontext */, attr_
+                            parse_ok = rule_impl::parse_rhs(
+                                rhs, first, last, rcontext, attr_
                             );
                         }
                     }
                 }
+
                 if (parse_ok)
                 {
-                    // do up-stream transformation, this integrates the results
-                    // back into the original attribute value, if appropriate
+                    // Integrate the results back into the original attribute value, if appropriate
                     transform::post(attr, std::forward<transform_attr>(attr_));
                 }
                 return parse_ok;
             }
         };
 
+        template <typename RuleID, X4Subject RHS, typename Attribute, bool ForceAttribute, bool SkipDefinitionInjection = false>
+        struct rule_definition : parser<rule_definition<RuleID, RHS, Attribute, ForceAttribute, SkipDefinitionInjection>>
+        {
+            using this_type = rule_definition;
+            using id = RuleID;
+            using rhs_type = RHS;
+            using lhs_type = rule<RuleID, Attribute, ForceAttribute>;
+            using attribute_type = Attribute;
+
+            static constexpr bool has_attribute = !std::same_as<Attribute, unused_type>;
+            static constexpr bool handles_container = traits::is_container<Attribute>::value;
+            static constexpr bool force_attribute = ForceAttribute;
+
+            template <typename RHS_T>
+                requires std::is_constructible_v<RHS, RHS_T>
+            constexpr rule_definition(RHS_T&& rhs, char const* name)
+                noexcept(std::is_nothrow_constructible_v<RHS, RHS_T>)
+                : rhs(std::forward<RHS_T>(rhs))
+                , name(name)
+            {}
+
+            template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute_>
+            [[nodiscard]] constexpr bool
+            parse(It& first, Se const& last, Context const& context, Attribute_& attr) const
+                // never noexcept; requires very complex implementation details
+            {
+                return rule_impl<attribute_type, RuleID, SkipDefinitionInjection>
+                    ::template call_rule_definition<ForceAttribute>(
+                        rhs, name, first, last, context, attr
+                    );
+            }
+
+            RHS rhs;
+            char const* name = "unnamed";
+        };
+
     } // detail
 
-
-    template <typename ID, X4Subject RHS, typename Attribute, bool ForceAttribute, bool SkipDefinitionInjection = false>
-    struct rule_definition : parser<rule_definition<ID, RHS, Attribute, ForceAttribute, SkipDefinitionInjection>>
+    template <typename RuleID, typename Attribute, bool ForceAttribute>
+    struct rule : parser<rule<RuleID, Attribute, ForceAttribute>>
     {
-        using this_type = rule_definition<ID, RHS, Attribute, ForceAttribute, SkipDefinitionInjection>;
-        using id = ID;
-        using rhs_type = RHS;
-        using lhs_type = rule<ID, Attribute, ForceAttribute>;
+        static_assert(!std::is_reference_v<Attribute>, "reference type is not allowed for rule attribute type");
+        static_assert(X4Attribute<Attribute>);
+
+        using id = RuleID;
         using attribute_type = Attribute;
 
-        static constexpr bool has_attribute = !std::is_same_v<Attribute, unused_type>;
-        static constexpr bool handles_container = traits::is_container<Attribute>::value;
-        static constexpr bool force_attribute = ForceAttribute;
-
-        template <typename RHS_T>
-            requires std::is_constructible_v<RHS, RHS_T>
-        constexpr rule_definition(RHS_T&& rhs, char const* name)
-            noexcept(std::is_nothrow_constructible_v<RHS, RHS_T>)
-            : rhs(std::forward<RHS_T>(rhs))
-            , name(name)
-        {}
-
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute_>
-        [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute_& attr) const
-            // never noexcept; requires very complex implementation details
-        {
-            return detail::rule_parser<attribute_type, ID, SkipDefinitionInjection>
-                ::template call_rule_definition<ForceAttribute>(
-                    rhs, name, first, last, context, attr
-                );
-        }
-
-        RHS rhs;
-        char const* name = "unnamed";
-    };
-
-    template <typename ID, typename Attribute, bool ForceAttribute>
-    struct rule : parser<rule<ID, Attribute, ForceAttribute>>
-    {
-        static_assert(!std::is_reference_v<Attribute>, "Reference qualifier on rule attribute type is meaningless");
-
-        using id = ID;
-        using attribute_type = Attribute;
-        static constexpr bool has_attribute = !std::is_same_v<std::remove_const_t<Attribute>, unused_type>;
+        static constexpr bool has_attribute = !std::same_as<std::remove_const_t<Attribute>, unused_type>;
         static constexpr bool handles_container = traits::is_container_v<std::remove_const_t<Attribute>>;
         static constexpr bool force_attribute = ForceAttribute;
+
+        char const* name = "unnamed";
 
 #ifndef BOOST_SPIRIT_X4_NO_RTTI
         rule() : name(typeid(rule).name()) {}
@@ -513,70 +353,11 @@ namespace boost::spirit::x4
             assert(r.name != nullptr && "uninitialized rule"); // static initialization order fiasco
         }
 
-        template <X4Subject RHS>
-        [[nodiscard]] constexpr rule_definition<ID, as_parser_plain_t<RHS>, Attribute, ForceAttribute>
-        operator=(RHS&& rhs) const&
-            noexcept(
-                is_parser_nothrow_castable_v<RHS> &&
-                std::is_nothrow_constructible_v<
-                    rule_definition<ID, as_parser_plain_t<RHS>, Attribute, ForceAttribute>,
-                    as_parser_t<RHS>, char const*
-                >
-            )
-        {
-            return { as_parser(std::forward<RHS>(rhs)), name };
-        }
-
-        template <X4Subject RHS>
-        [[nodiscard]] constexpr rule_definition<ID, as_parser_plain_t<RHS>, Attribute, true>
-        operator%=(RHS&& rhs) const&
-            noexcept(
-                is_parser_nothrow_castable_v<RHS> &&
-                std::is_nothrow_constructible_v<
-                    rule_definition<ID, as_parser_plain_t<RHS>, Attribute, true>,
-                    as_parser_t<RHS>, char const*
-                >
-            )
-        {
-            return { as_parser(std::forward<RHS>(rhs)), name };
-        }
-
-        // When a rule placeholder constructed and immediately consumed it cannot be used recursively,
-        // that's why the rule definition injection into a parser context can be skipped.
-        // This optimization has a huge impact on compile times because immediate rules are commonly
-        // used to cast an attribute like `as`/`attr_cast` does in Qi.
-        template <X4Subject RHS>
-        [[nodiscard]] constexpr rule_definition<ID, as_parser_plain_t<RHS>, Attribute, ForceAttribute, true>
-        operator=(RHS&& rhs) const&&
-            noexcept(
-                is_parser_nothrow_castable_v<RHS> &&
-                std::is_nothrow_constructible_v<
-                    rule_definition<ID, as_parser_plain_t<RHS>, Attribute, ForceAttribute, true>,
-                    as_parser_t<RHS>, char const*
-                >
-            )
-        {
-            return { as_parser(std::forward<RHS>(rhs)), name };
-        }
-
-        template <X4Subject RHS>
-        [[nodiscard]] constexpr rule_definition<ID, as_parser_plain_t<RHS>, Attribute, true, true>
-        operator%=(RHS&& rhs) const&&
-            noexcept(
-                is_parser_nothrow_castable_v<RHS> &&
-                std::is_nothrow_constructible_v<
-                    rule_definition<ID, as_parser_plain_t<RHS>, Attribute, true, true>,
-                    as_parser_t<RHS>, char const*
-                >
-            )
-        {
-            return { as_parser(std::forward<RHS>(rhs)), name };
-        }
-
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Exposed>
-            requires (!std::is_same_v<std::remove_const_t<Exposed>, unused_type>)
+        // Primary overload
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Exposed>
+            requires (!std::same_as<std::remove_const_t<Exposed>, unused_type>)
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Exposed& exposed_attr) const
+        parse(It& first, Se const& last, Context const& context, Exposed& exposed_attr) const
             // never noexcept; requires very complex implementation details
         {
             static_assert(has_attribute, "A rule must have an attribute. Check your rule definition.");
@@ -592,68 +373,138 @@ namespace boost::spirit::x4
             using transformed_type = typename transform::type;
             transformed_type transformed_attr = transform::pre(exposed_attr);
 
+            // Remove the `_val` context. This makes the actual `context` type passed to
+            // the (potentially ADL-found) `parse_rule` function to be rule-agnostic.
+            // If we don't do this, the specialized function signature becomes
+            // nondeterministic, and we lose the opportunity to do explicit template
+            // instantiation in `BOOST_SPIRIT_X4_INSTANTIATE`.
+            //
+            // Note that this removal is possible only because the actual invocation of
+            // `parse_rule` *ALWAYS* results in subsequent invocation of `call_rule_definition`,
+            // which resets the `_val` context to the appropriate reference.
+            auto&& non_rule_specific_ctx = x4::remove_first_context<rule_val_context_tag>(context);
+
             // ADL
-            if (static_cast<bool>(parse_rule(detail::rule_id<ID>{}, first, last, context, transformed_attr))) {
+            using detail::parse_rule;
+            if (static_cast<bool>(parse_rule(detail::rule_id<RuleID>{}, first, last, non_rule_specific_ctx, transformed_attr))) {
                 transform::post(exposed_attr, std::forward<transformed_type>(transformed_attr));
                 return true;
             }
             return false;
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, unused_type const&) const
+        parse(It& first, Se const& last, Context const& context, unused_type const&) const
             // never noexcept; requires very complex implementation details
         {
             // make sure we pass exactly the rule attribute type
             attribute_type no_attr; // default-initialize
 
+            // See the comments on the primary overload of `rule::parse(...)`
+            auto&& non_rule_specific_ctx = x4::remove_first_context<rule_val_context_tag>(context);
+
             // ADL
-            return static_cast<bool>(parse_rule(detail::rule_id<ID>{}, first, last, context, no_attr));
+            using detail::parse_rule;
+            return static_cast<bool>(parse_rule(detail::rule_id<RuleID>{}, first, last, non_rule_specific_ctx, no_attr));
         }
 
-        char const* name = "unnamed";
-    };
-
-    namespace traits
-    {
-        template <typename T>
-        struct is_rule : std::false_type {};
-
-        template <typename T>
-        constexpr bool is_rule_v = is_rule<T>::value;
-
-        template <typename ID, typename Attribute, bool ForceAttribute>
-        struct is_rule<rule<ID, Attribute, ForceAttribute>> : std::true_type {};
-
-        template <typename ID, typename Attribute, typename RHS, bool ForceAttribute, bool SkipDefinitionInjection>
-        struct is_rule<rule_definition<ID, RHS, Attribute, ForceAttribute, SkipDefinitionInjection>> : std::true_type {};
-    }
-
-    template <typename T>
-        requires traits::is_rule_v<T>
-    struct get_info<T>
-    {
-        using result_type = std::string;
-        [[nodiscard]] std::string operator()(T const& r) const
+        template <X4Subject RHS>
+        [[nodiscard]] constexpr detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, ForceAttribute>  // NOLINT(misc-unconventional-assign-operator)
+        operator=(RHS&& rhs) const&
+            noexcept(
+                is_parser_nothrow_castable_v<RHS> &&
+                std::is_nothrow_constructible_v<
+                    detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, ForceAttribute>,
+                    as_parser_t<RHS>, char const*
+                >
+            )
         {
-            assert(r.name != nullptr && "uninitialized rule"); // static initialization order fiasco
-            return r.name? r.name : "uninitialized";
+            return { as_parser(std::forward<RHS>(rhs)), name };
+        }
+
+        template <X4Subject RHS>
+        [[nodiscard]] constexpr detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, true>
+        operator%=(RHS&& rhs) const&
+            noexcept(
+                is_parser_nothrow_castable_v<RHS> &&
+                std::is_nothrow_constructible_v<
+                    detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, true>,
+                    as_parser_t<RHS>, char const*
+                >
+            )
+        {
+            return { as_parser(std::forward<RHS>(rhs)), name };
+        }
+
+        // When a rule placeholder constructed and immediately consumed it cannot be used recursively,
+        // that's why the rule definition injection into a parser context can be skipped.
+        // This optimization has a huge impact on compile times because immediate rules are commonly
+        // used to cast an attribute like `as`/`attr_cast` does in Qi.
+        template <X4Subject RHS>
+        [[nodiscard]] constexpr detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, ForceAttribute, true>  // NOLINT(misc-unconventional-assign-operator)
+        operator=(RHS&& rhs) const&&
+            noexcept(
+                is_parser_nothrow_castable_v<RHS> &&
+                std::is_nothrow_constructible_v<
+                    detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, ForceAttribute, true>,
+                    as_parser_t<RHS>, char const*
+                >
+            )
+        {
+            return { as_parser(std::forward<RHS>(rhs)), name };
+        }
+
+        template <X4Subject RHS>
+        [[nodiscard]] constexpr detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, true, true>
+        operator%=(RHS&& rhs) const&&
+            noexcept(
+                is_parser_nothrow_castable_v<RHS> &&
+                std::is_nothrow_constructible_v<
+                    detail::rule_definition<RuleID, as_parser_plain_t<RHS>, Attribute, true, true>,
+                    as_parser_t<RHS>, char const*
+                >
+            )
+        {
+            return { as_parser(std::forward<RHS>(rhs)), name };
         }
     };
+
+    namespace detail
+    {
+        struct rule_get_info
+        {
+            using result_type = std::string;
+
+            template <typename RuleT> // `rule` or `rule_definition`
+            [[nodiscard]] static std::string operator()(RuleT const& rule_like)
+            {
+                assert(rule_like.name != nullptr && "uninitialized rule"); // static initialization order fiasco
+                return rule_like.name ? rule_like.name : "uninitialized";
+            }
+        };
+
+    } // detail
+
+    template <typename RuleID, typename Attribute, bool ForceAttribute>
+    struct get_info<rule<RuleID, Attribute, ForceAttribute>> : detail::rule_get_info {};
+
+    template <typename RuleID, typename Attribute, typename RHS, bool ForceAttribute, bool SkipDefinitionInjection>
+    struct get_info<detail::rule_definition<RuleID, RHS, Attribute, ForceAttribute, SkipDefinitionInjection>> : detail::rule_get_info {};
 
 // -------------------------------------------------------------
 
 #define BOOST_SPIRIT_X4_DEPRECATED_MACRO_WARN_I(x) _Pragma(#x)
 #define BOOST_SPIRIT_X4_DEPRECATED_MACRO_WARN(msg) BOOST_SPIRIT_X4_DEPRECATED_MACRO_WARN_I(message(msg))
 
-#define BOOST_SPIRIT_X4_DECLARE_(r, constexpr_, rule_type)                                       \
-    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>           \
-    [[nodiscard]] constexpr_ bool                                                             \
-    parse_rule(                                                                               \
-        ::boost::spirit::x4::detail::rule_id<typename std::remove_cvref_t<rule_type>::id>,    \
-        It& first, Se const& last,                                                            \
-        Context const& context, typename std::remove_cvref_t<rule_type>::attribute_type& attr \
+#define BOOST_SPIRIT_X4_DECLARE_(r, constexpr_, rule_type) \
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context> \
+    [[nodiscard]] constexpr_ bool \
+    parse_rule( \
+        ::boost::spirit::x4::detail::rule_id<typename std::remove_cvref_t<rule_type>::id>, \
+        It& first, Se const& last, \
+        Context const& context, \
+        typename std::remove_cvref_t<rule_type>::attribute_type& attr \
     );
 
 #define BOOST_SPIRIT_X4_DECLARE(rule_type) BOOST_SPIRIT_X4_DECLARE_(,, rule_type)
@@ -667,27 +518,28 @@ namespace boost::spirit::x4
 #define BOOST_SPIRIT_DECLARE(...) \
     BOOST_SPIRIT_X4_DEPRECATED_MACRO_WARN( \
         "Use of variadic arguments with `BOOST_SPIRIT_DECLARE` is deprecated due to the heavy compile-time cost of " \
-	"`BOOST_PP_SEQ_*`. Just apply `BOOST_SPIRIT_X4_DECLARE` for each of your rules." \
+    "`BOOST_PP_SEQ_*`. Just apply `BOOST_SPIRIT_X4_DECLARE` for each of your rules." \
     ) \
     BOOST_PP_SEQ_FOR_EACH(BOOST_SPIRIT_X4_DECLARE_,, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
+// -------------------------------------------------------------
 
-#define BOOST_SPIRIT_X4_DEFINE_(r, constexpr_, rule_name)                                      \
-    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>         \
-    [[nodiscard]] constexpr_ bool                                                           \
-    parse_rule(                                                                             \
-        ::boost::spirit::x4::detail::rule_id<std::remove_cvref_t<decltype(rule_name)>::id>, \
-        It& first, Se const& last,                                                          \
-        Context const& context,                                                             \
-        std::remove_cvref_t<decltype(rule_name)>::attribute_type& attr                      \
-    ) {                                                                                     \
-        using rule_t = std::remove_cvref_t<decltype(rule_name)>;                            \
-        return ::boost::spirit::x4::detail::rule_parser<                                    \
-            typename rule_t::attribute_type, typename rule_t::id, true                      \
-        >::call_rule_definition<rule_t::force_attribute>(                                   \
-            BOOST_JOIN(rule_name, _def), rule_name.name,                                    \
-            first, last, context, attr                                                      \
-        );                                                                                  \
+#define BOOST_SPIRIT_X4_DEFINE_(r, constexpr_, rule_name) \
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context> \
+    [[nodiscard]] constexpr_ bool \
+    parse_rule( \
+        ::boost::spirit::x4::detail::rule_id<typename std::remove_cvref_t<decltype(rule_name)>::id>, \
+        It& first, Se const& last, \
+        Context const& context, \
+        typename std::remove_cvref_t<decltype(rule_name)>::attribute_type& attr \
+    ) { \
+        using rule_t = std::remove_cvref_t<decltype(rule_name)>; \
+        return ::boost::spirit::x4::detail::rule_impl< \
+            typename rule_t::attribute_type, typename rule_t::id, true \
+        >::call_rule_definition<rule_t::force_attribute>( \
+            BOOST_SPIRIT_CONCAT(rule_name, _def), rule_name.name, \
+            first, last, context, attr \
+        ); \
     }
 
 #define BOOST_SPIRIT_X4_DEFINE(rule_type) BOOST_SPIRIT_X4_DEFINE_(,, rule_type)
@@ -701,38 +553,49 @@ namespace boost::spirit::x4
 #define BOOST_SPIRIT_DEFINE(...) \
     BOOST_SPIRIT_X4_DEPRECATED_MACRO_WARN( \
         "Use of variadic arguments with `BOOST_SPIRIT_DEFINE` is deprecated due to the heavy compile-time cost of " \
-	"`BOOST_PP_SEQ_*`. Just apply `BOOST_SPIRIT_X4_DEFINE` for each of your rules." \
+    "`BOOST_PP_SEQ_*`. Just apply `BOOST_SPIRIT_X4_DEFINE` for each of your rules." \
     ) \
     BOOST_PP_SEQ_FOR_EACH(BOOST_SPIRIT_X4_DEFINE_,, BOOST_PP_VARIADIC_TO_SEQ(__VA_ARGS__))
 
+// -------------------------------------------------------------
+
     namespace detail
     {
+        // New API
         template <typename RuleT, std::forward_iterator It, typename A, typename B = void>
         struct instantiate_macro_helper
         {
             using rule_type = RuleT;
             using iterator_type = It;
 
-            // Old API:
-            //  A => Context
-            //  B => void
-
-            // New API:
-            //  A => Se
-            //  B => Context
-
-            using sentinel_type = std::conditional_t<std::is_void_v<B>, It, A>;
+            using sentinel_type = A;
             static_assert(std::sentinel_for<sentinel_type, It>);
 
-            using context_type = std::conditional_t<std::is_void_v<B>, A, B>;
+            using context_type = B;
         };
+
+        // Old API
+        template <typename RuleT, std::forward_iterator It, typename Context>
+        struct instantiate_macro_helper<RuleT, It, Context, void>
+        {
+            using rule_type = RuleT;
+            using iterator_type = It;
+            using sentinel_type = It;
+            using context_type = Context;
+        };
+
     } // detail
 
-#define BOOST_SPIRIT_X4_INSTANTIATE_(rule_type, It, Se, Context)                           \
-    template bool parse_rule<It, Se, Context>(                                             \
+#define BOOST_SPIRIT_X4_INSTANTIATE_(rule_type, It, Se, Context) \
+    /* non-recursively invoked version */ \
+    template bool parse_rule< \
+        It, Se, \
+        Context \
+    >( \
         ::boost::spirit::x4::detail::rule_id<typename std::remove_cvref_t<rule_type>::id>, \
-        It&, Se const&, Context const&,                                                    \
-        typename std::remove_cvref_t<rule_type>::attribute_type&                           \
+        It&, Se const&,\
+        Context const&, /* non-recursively invoked context is the plain `Context` */ \
+        typename std::remove_cvref_t<rule_type>::attribute_type& \
     );
 
 #define BOOST_SPIRIT_X4_INSTANTIATE_WRAP(...) __VA_ARGS__

--- a/include/boost/spirit/x4/string/literal_string.hpp
+++ b/include/boost/spirit/x4/string/literal_string.hpp
@@ -47,9 +47,9 @@ namespace boost::spirit::x4
             : str(std::forward<Args>(args)...)
         {}
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute_>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute_>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute_& attr
+        parse(It& first, Se const& last, Context const& context, Attribute_& attr
         ) const
             noexcept(
                 noexcept(x4::skip_over(first, last, context)) &&

--- a/include/boost/spirit/x4/symbols.hpp
+++ b/include/boost/spirit/x4/symbols.hpp
@@ -244,9 +244,9 @@ namespace detail
             return this->find_impl(s.begin(), s.end());
         }
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool
-        parse(It& first, Se const& last, Context const& context, RContext const&, Attribute& attr) const
+        parse(It& first, Se const& last, Context const& context, Attribute& attr) const
             noexcept(
                 noexcept(x4::skip_over(first, last, context)) &&
                 noexcept(x4::move_to(std::declval<value_type const&>(), attr))

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -78,6 +78,7 @@ x4_define_tests(
     no_skip
     omit
     optional
+    parser
     plus
     raw
     real1

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -57,6 +57,7 @@ x4_define_tests(
     char_class
     confix
     container_support
+    context
     debug
     difference
     eoi

--- a/test/x4/Jamfile
+++ b/test/x4/Jamfile
@@ -59,6 +59,7 @@ rule compile-fail ( sources + : requirements * : target-name ? )
 }
 
 run parser.cpp ;
+run context.cpp ;
 
 run actions.cpp ;
 run alternative.cpp ;

--- a/test/x4/Jamfile
+++ b/test/x4/Jamfile
@@ -58,6 +58,8 @@ rule compile-fail ( sources + : requirements * : target-name ? )
            : $(requirements) : $(target-name) ] ;
 }
 
+run parser.cpp ;
+
 run actions.cpp ;
 run alternative.cpp ;
 run and_predicate.cpp ;

--- a/test/x4/alternative.cpp
+++ b/test/x4/alternative.cpp
@@ -57,7 +57,6 @@ int main()
     using x4::standard::lit;
     using x4::attr;
     using x4::int_;
-    using x4::unused_type;
     using x4::unused;
     using x4::omit;
     using x4::eps;

--- a/test/x4/attribute_type_check.cpp
+++ b/test/x4/attribute_type_check.cpp
@@ -16,6 +16,7 @@
 #include <boost/fusion/include/make_vector.hpp>
 #include <boost/fusion/include/equal_to.hpp>
 
+#include <iterator>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -24,18 +25,17 @@
 template <typename Value, typename Expected>
 struct checked_attr_parser : x4::attr_parser<Value>
 {
-    using base_t = x4::attr_parser<Value>;
+    using base_type = x4::attr_parser<Value>;
 
-    checked_attr_parser(Value const& value) : base_t(value) {}
-    checked_attr_parser(Value&& value) : base_t(std::move(value)) {}
+    checked_attr_parser(Value const& value) : base_type(value) {}
+    checked_attr_parser(Value&& value) : base_type(std::move(value)) {}
 
-    template <typename Iterator, typename Context
-      , typename RuleContext, typename Attribute>
-    bool parse(Iterator& first, Iterator const& last
-      , Context const& ctx, RuleContext& rctx, Attribute& attr_) const
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, Attribute& attr_) const
     {
         static_assert(std::is_same_v<Expected, Attribute>, "attribute type check failed");
-        return base_t::parse(first, last, ctx, rctx, attr_);
+        return base_type::parse(first, last, ctx, attr_);
     }
 };
 

--- a/test/x4/char_class.cpp
+++ b/test/x4/char_class.cpp
@@ -20,8 +20,6 @@
 
 int main()
 {
-    using x4::unused_type;
-
     {
         using namespace x4::standard;
         BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(alnum);
@@ -175,7 +173,7 @@ int main()
         using x4::standard::alpha;
         using x4::standard::space;
         char attr = 0;
-        BOOST_TEST(parse("     a", alpha, attr, space));
+        BOOST_TEST(parse("     a", alpha, space, attr));
         BOOST_TEST(attr == 'a');
     }
 

--- a/test/x4/confix.cpp
+++ b/test/x4/confix.cpp
@@ -36,7 +36,7 @@ int main()
         {
             unsigned value = 0;
             BOOST_TEST(
-                parse(" /* 123 */ ", comment[x4::uint_], value, x4::standard::space));
+                parse(" /* 123 */ ", comment[x4::uint_], x4::standard::space, value));
             BOOST_TEST(value == 123);
 
             using x4::_attr;

--- a/test/x4/context.cpp
+++ b/test/x4/context.cpp
@@ -1,0 +1,184 @@
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "test.hpp"
+
+#include <boost/spirit/x4/core/context.hpp>
+
+#include <concepts>
+#include <memory>
+#include <utility>
+
+int main()
+{
+    using x4::context;
+    using x4::owning_context;
+
+    struct tag;
+    struct nonexistent_tag;
+
+    {
+        int i = 42;
+        auto ctx = x4::make_context<tag>(std::as_const(i));
+        BOOST_TEST(x4::get<tag>(ctx) == 42);
+        static_assert(std::same_as<decltype(x4::get<tag>(ctx)), int const&>);
+        static_assert(std::same_as<decltype(x4::get<tag>(std::as_const(ctx))), int const&>);
+    }
+
+    // Start with plain `context<tag, int>`
+    {
+        int i = 42;
+        auto ctx = x4::make_context<tag>(i);
+        static_assert(std::same_as<decltype(ctx), context<tag, int>>);
+        BOOST_TEST(x4::get<tag>(ctx) == 42);
+        static_assert(std::same_as<decltype(x4::get<tag>(ctx)), int&>);
+        static_assert(std::same_as<decltype(x4::get<tag>(std::as_const(ctx))), int&>);
+        BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+
+        {
+            int j = 999;
+            auto&& replaced_ctx = x4::replace_first_context<tag>(ctx, j);
+            static_assert(std::same_as<decltype(replaced_ctx), context<tag, int>&&>);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 999);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(j));
+
+            {
+                auto&& removed_ctx = x4::remove_first_context<nonexistent_tag>(replaced_ctx);
+                static_assert(std::same_as<decltype(removed_ctx), context<tag, int> const&>);
+                BOOST_TEST(std::addressof(removed_ctx) == std::addressof(replaced_ctx));
+            }
+            {
+                auto&& removed_ctx = x4::remove_first_context<tag>(replaced_ctx);
+                static_assert(std::same_as<decltype(removed_ctx), x4::detail::monostate_context&&>);
+
+                {
+                    [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<tag>(removed_ctx);
+                    static_assert(std::same_as<decltype(removed_removed_ctx), x4::detail::monostate_context const&>);
+                }
+                {
+                    [[maybe_unused]] auto&& new_ctx = x4::make_context<tag>(i, removed_ctx);
+                    static_assert(std::same_as<decltype(new_ctx), context<tag, int>&&>);
+                }
+                {
+                    auto&& new_ctx = x4::replace_first_context<tag>(removed_ctx, i);
+                    static_assert(std::same_as<decltype(new_ctx), context<tag, int>&&>);
+                    BOOST_TEST(std::addressof(new_ctx.val) == std::addressof(i));
+                }
+            }
+        }
+        {
+            double d = 3.14;
+            auto replaced_ctx = x4::replace_first_context<tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<tag, double>>);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 3.14);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(d));
+        }
+        {
+            double d = 3.14;
+            auto replaced_ctx = x4::replace_first_context<nonexistent_tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<tag, int, owning_context<context<nonexistent_tag, double>>>>);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 42);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(x4::get<nonexistent_tag>(replaced_ctx)) == std::addressof(d));
+        }
+    }
+
+    // Start with nested; `context<dummy_tag, dummy_t const, context<tag, int>>`
+    {
+        struct dummy_tag;
+        struct dummy_t {};
+        constexpr dummy_t dummy;
+
+        auto const dummy_ctx = x4::make_context<dummy_tag>(dummy);
+        using dummy_ctx_t = context<dummy_tag, dummy_t const>;
+        static_assert(std::same_as<decltype(dummy_ctx), dummy_ctx_t const>);
+
+        int i = 42;
+        auto ctx = x4::make_context<tag>(i, dummy_ctx);
+        static_assert(std::same_as<decltype(ctx), context<tag, int, dummy_ctx_t>>);
+        BOOST_TEST(x4::get<tag>(ctx) == 42);
+        static_assert(std::same_as<decltype(x4::get<tag>(ctx)), int&>);
+        static_assert(std::same_as<decltype(x4::get<tag>(std::as_const(ctx))), int&>);
+        BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+
+        {
+            int j = 999;
+            auto&& replaced_ctx = x4::replace_first_context<tag>(ctx, j);
+            static_assert(std::same_as<decltype(replaced_ctx), context<tag, int, dummy_ctx_t>&&>);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 999);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(j));
+
+            {
+                auto&& removed_ctx = x4::remove_first_context<nonexistent_tag>(replaced_ctx);
+                static_assert(std::same_as<decltype(removed_ctx), context<tag, int, dummy_ctx_t> const&>);
+                BOOST_TEST(std::addressof(removed_ctx) == std::addressof(replaced_ctx));
+
+                {
+                    [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<tag>(removed_ctx);
+                    static_assert(std::same_as<decltype(removed_removed_ctx), dummy_ctx_t const&>);
+                }
+                {
+                    [[maybe_unused]] auto&& new_ctx = x4::make_context<nonexistent_tag>(i, removed_ctx);
+                    static_assert(std::same_as<decltype(new_ctx), context<nonexistent_tag, int, context<tag, int, dummy_ctx_t>>&&>);
+                }
+                {
+                    auto&& new_ctx = x4::replace_first_context<tag>(removed_ctx, i);
+                    static_assert(std::same_as<decltype(new_ctx), context<tag, int, dummy_ctx_t>&&>);
+                    BOOST_TEST(std::addressof(new_ctx.val) == std::addressof(i));
+                }
+            }
+        }
+        {
+            double d = 3.14;
+            auto&& replaced_ctx = x4::replace_first_context<tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<tag, double, dummy_ctx_t>&&>);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 3.14);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(d));
+        }
+        {
+            double d = 3.14;
+            auto&& replaced_ctx = x4::replace_first_context<dummy_tag>(ctx, d);
+            static_assert(std::same_as<
+                decltype(replaced_ctx),
+                context<
+                    tag, int,
+                    owning_context<context<
+                        dummy_tag, double
+                    >>
+                >&&
+            >);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 42);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(x4::get<dummy_tag>(replaced_ctx)) == std::addressof(d));
+        }
+        {
+            double d = 3.14;
+            auto&& replaced_ctx = x4::replace_first_context<nonexistent_tag>(ctx, d);
+            static_assert(std::same_as<
+                decltype(replaced_ctx),
+                context<
+                    tag, int,
+                    owning_context<context<
+                        dummy_tag, dummy_t const,
+                        owning_context<context<
+                            nonexistent_tag, double
+                        >>
+                    >>
+                >&&
+            >);
+            BOOST_TEST(x4::get<tag>(replaced_ctx) == 42);
+            BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
+            BOOST_TEST(std::addressof(x4::get<nonexistent_tag>(replaced_ctx)) == std::addressof(d));
+        }
+    }
+
+    return boost::report_errors();
+}

--- a/test/x4/eps.cpp
+++ b/test/x4/eps.cpp
@@ -33,8 +33,8 @@ int main()
 
     {   // test lazy semantic predicate
 
-        auto true_ = [](unused_type) { return true; };
-        auto false_ = [](unused_type) { return false; };
+        auto true_ = [] { return true; };
+        auto false_ = [] { return false; };
 
         // cannot use lambda in constant expression before C++17
         BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(eps(std::true_type{}));

--- a/test/x4/eps.cpp
+++ b/test/x4/eps.cpp
@@ -14,7 +14,6 @@
 int main()
 {
     using x4::eps;
-    using x4::unused_type;
 
     {
         BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(eps);

--- a/test/x4/grammar.cpp
+++ b/test/x4/grammar.cpp
@@ -14,4 +14,8 @@
 auto const grammar_def = x4::int_;
 
 BOOST_SPIRIT_X4_DEFINE(grammar)
-BOOST_SPIRIT_X4_INSTANTIATE(grammar_type, char const*, x4::parse_context_for<char const*>)
+BOOST_SPIRIT_X4_INSTANTIATE(
+    grammar_type,
+    char const*,
+    x4::parse_context_for<char const*>
+)

--- a/test/x4/int.cpp
+++ b/test/x4/int.cpp
@@ -175,7 +175,6 @@ int main()
     // int_parser<unused_type> tests
     {
         using x4::int_parser;
-        using x4::unused_type;
         constexpr int_parser<unused_type> any_int{};
 
         BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(any_int);

--- a/test/x4/kleene.cpp
+++ b/test/x4/kleene.cpp
@@ -69,24 +69,24 @@ int main()
         BOOST_TEST(parse("bbbb", *char_, s) && 4 == s.size() && s == "bbbb");
 
         s.clear();
-        BOOST_TEST(parse("b b b b ", *char_, s, space)  && s == "bbbb");
+        BOOST_TEST(parse("b b b b ", *char_, space, s)  && s == "bbbb");
     }
 
     {
         std::vector<int> v;
-        BOOST_TEST(parse("123 456 789 10", *int_, v, space) && 4 == v.size() &&
+        BOOST_TEST(parse("123 456 789 10", *int_, space, v) && 4 == v.size() &&
             v[0] == 123 && v[1] == 456 && v[2] == 789 &&  v[3] == 10);
     }
 
     {
         std::vector<std::string> v;
-        BOOST_TEST(parse("a b c d", *lexeme[+alpha], v, space) && 4 == v.size() &&
+        BOOST_TEST(parse("a b c d", *lexeme[+alpha], space, v) && 4 == v.size() &&
             v[0] == "a" && v[1] == "b" && v[2] == "c" &&  v[3] == "d");
     }
 
     {
         std::vector<int> v;
-        BOOST_TEST(parse("123 456 789", *int_, v, space) && 3 == v.size() &&
+        BOOST_TEST(parse("123 456 789", *int_, space, v) && 3 == v.size() &&
             v[0] == 123 && v[1] == 456 && v[2] == 789);
     }
 

--- a/test/x4/no_skip.cpp
+++ b/test/x4/no_skip.cpp
@@ -42,12 +42,12 @@ int main()
     // with skipping, no_skip allows to match a leading skipper
     {
         std::string str;
-        BOOST_TEST(parse("'  abc '", '\'' >> no_skip[+~char_('\'')] >> '\'', str, space));
+        BOOST_TEST(parse("'  abc '", '\'' >> no_skip[+~char_('\'')] >> '\'', space, str));
         BOOST_TEST(str == "  abc ");
     }
     {
         std::string str;
-        BOOST_TEST(parse("'  abc '", '\'' >> lexeme[+~char_('\'')] >> '\'', str, space));
+        BOOST_TEST(parse("'  abc '", '\'' >> lexeme[+~char_('\'')] >> '\'', space, str));
         BOOST_TEST(str == "abc ");
     }
 

--- a/test/x4/omit.cpp
+++ b/test/x4/omit.cpp
@@ -101,7 +101,7 @@ int main()
     {
         // if only one node in a sequence is left (all the others are omitted),
         // then we need "naked" attributes (not wrapped in a tuple)
-        int attr;
+        int attr = 0;
         BOOST_TEST(parse("a 123 c", omit['a'] >> int_ >> omit['c'], attr, space));
         BOOST_TEST((attr == 123));
     }

--- a/test/x4/omit.cpp
+++ b/test/x4/omit.cpp
@@ -35,8 +35,6 @@ int main()
 {
     using namespace x4::standard;
     using x4::omit;
-    using x4::unused_type;
-    using x4::unused;
     using x4::int_;
     using x4::_attr;
 
@@ -93,7 +91,7 @@ int main()
     {
         // "hello" has an unused_type. unused attrubutes are not part of the sequence
         vector<char, char> attr;
-        BOOST_TEST(parse("a hello c", char_ >> "hello" >> char_, attr, space));
+        BOOST_TEST(parse("a hello c", char_ >> "hello" >> char_, space, attr));
         BOOST_TEST((at_c<0>(attr) == 'a'));
         BOOST_TEST((at_c<1>(attr) == 'c'));
     }
@@ -102,7 +100,7 @@ int main()
         // if only one node in a sequence is left (all the others are omitted),
         // then we need "naked" attributes (not wrapped in a tuple)
         int attr = 0;
-        BOOST_TEST(parse("a 123 c", omit['a'] >> int_ >> omit['c'], attr, space));
+        BOOST_TEST(parse("a 123 c", omit['a'] >> int_ >> omit['c'], space, attr));
         BOOST_TEST((attr == 123));
     }
 

--- a/test/x4/optional.cpp
+++ b/test/x4/optional.cpp
@@ -116,7 +116,7 @@ int main()
 
     {
         std::vector<adata> v;
-        BOOST_TEST(parse("a 1 2 a 2", *('a' >> int_ >> -int_), v, char_(' ')));
+        BOOST_TEST(parse("a 1 2 a 2", *('a' >> int_ >> -int_), char_(' '), v));
         BOOST_TEST(
             2 == v.size() &&
             1 == v[0].a && v[0].b && 2 == *(v[0].b) &&

--- a/test/x4/parser.cpp
+++ b/test/x4/parser.cpp
@@ -1,0 +1,251 @@
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "test.hpp"
+
+#include <boost/spirit/x4/core/parser.hpp>
+#include <boost/spirit/x4/operator/sequence.hpp>
+#include <boost/spirit/x4/char/char_class.hpp>
+
+#include <iterator>
+#include <string_view>
+
+namespace {
+
+struct minimal_parser
+    : x4::parser<minimal_parser>
+{
+    constexpr minimal_parser() = default;
+
+    constexpr minimal_parser(minimal_parser const&) = delete;
+    constexpr minimal_parser& operator=(minimal_parser const&) = delete;
+
+    constexpr minimal_parser(minimal_parser&&) = default;
+    constexpr minimal_parser& operator=(minimal_parser&&) = default;
+
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, x4::X4Attribute Attribute>
+    [[nodiscard]] constexpr bool
+    parse(It&, Se const&, Context const&, Attribute&) const
+    {
+        return true;
+    }
+};
+
+struct minimal_unary_parser
+    : x4::unary_parser<minimal_parser, minimal_unary_parser>
+{
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, x4::X4Attribute Attribute>
+    [[nodiscard]] constexpr bool
+    parse(It&, Se const&, Context const&, Attribute&) const
+    {
+        return true;
+    }
+};
+
+struct minimal_binary_parser
+    : x4::binary_parser<minimal_parser, minimal_parser, minimal_binary_parser>
+{
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, x4::X4Attribute Attribute>
+    [[nodiscard]] constexpr bool
+    parse(It&, Se const&, Context const&, Attribute&) const
+    {
+        return true;
+    }
+};
+
+struct minimal_unused_parser
+    : x4::parser<minimal_unused_parser>
+{
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
+    [[nodiscard]] constexpr bool
+    parse(It&, Se const&, Context const&, unused_type const&) const
+    {
+        return true;
+    }
+};
+
+struct minimal_unary_unused_parser
+    : x4::unary_parser<minimal_unused_parser, minimal_unary_unused_parser>
+{
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
+    [[nodiscard]] constexpr bool
+    parse(It&, Se const&, Context const&, unused_type const&) const
+    {
+        return true;
+    }
+};
+
+struct minimal_binary_unused_parser
+    : x4::binary_parser<minimal_unused_parser, minimal_unused_parser, minimal_binary_unused_parser>
+{
+    template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context>
+    [[nodiscard]] constexpr bool
+    parse(It&, Se const&, Context const&, unused_type const&) const
+    {
+        return true;
+    }
+};
+
+} // anonymous
+
+int main()
+{
+    using x4::blank;
+
+    {
+        using It = std::string_view::const_iterator;
+        using Se = It;
+        static_assert(std::forward_iterator<It>);
+        static_assert(std::sentinel_for<Se, It>);
+
+        static_assert(x4::X4Subject<minimal_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_parser>);
+        static_assert(x4::is_parsable_v<minimal_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_parser, It, Se>);
+
+        // parse
+        {
+            // str
+            static_assert(x4::parse("", minimal_parser{}, unused));
+            // str + res
+            static_assert([] { x4::parse_result<It, Se> res{}; x4::parse(res, "", minimal_parser{}, unused); return res; }());
+
+            // It/Se
+            static_assert(x4::parse(It{}, Se{}, minimal_parser{}, unused));
+            // It/Se + res
+            static_assert([] { x4::parse_result<It, Se> res{}; x4::parse(res, It{}, Se{}, minimal_parser{}, unused); return res; }());
+        }
+
+        // phrase_parse
+        {
+            // str
+            static_assert(x4::parse("", minimal_parser{}, blank, unused));
+            // str + res
+            static_assert([] { x4::parse_result<It, Se> res{}; x4::parse(res, "", minimal_parser{}, blank, unused); return res; }());
+
+            // It/Se
+            static_assert(x4::parse(It{}, Se{}, minimal_parser{}, blank, unused));
+            // It/Se + res
+            static_assert([] { x4::parse_result<It, Se> res{}; x4::parse(res, It{}, Se{}, minimal_parser{}, blank, unused); return res; }());
+        }
+
+        // expectation
+        static_assert(x4::parse("", minimal_parser{} > minimal_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_unary_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_unary_parser>);
+        static_assert(x4::is_parsable_v<minimal_unary_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_unary_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_unary_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_unary_parser, It, Se>);
+        static_assert(x4::parse("", minimal_unary_parser{}, unused));
+        static_assert(x4::parse("", minimal_unary_parser{} > minimal_unary_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_binary_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_binary_parser>);
+        static_assert(x4::is_parsable_v<minimal_binary_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_binary_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_binary_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_binary_parser, It, Se>);
+        static_assert(x4::parse("", minimal_binary_parser{}, unused));
+        static_assert(x4::parse("", minimal_binary_parser{} > minimal_binary_parser{}, unused));
+
+
+        static_assert(x4::X4Subject<minimal_unused_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_unused_parser>);
+        static_assert(x4::is_parsable_v<minimal_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_unused_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_unused_parser, It, Se>);
+        static_assert(x4::parse("", minimal_unused_parser{}, unused));
+        static_assert(x4::parse("", minimal_unused_parser{} > minimal_unused_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_unary_unused_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_unary_unused_parser>);
+        static_assert(x4::is_parsable_v<minimal_unary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_unary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_unary_unused_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_unary_unused_parser, It, Se>);
+        static_assert(x4::parse("", minimal_unary_unused_parser{}, unused));
+        static_assert(x4::parse("", minimal_unary_unused_parser{} > minimal_unary_unused_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_binary_unused_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_binary_unused_parser>);
+        static_assert(x4::is_parsable_v<minimal_binary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_binary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_binary_unused_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_binary_unused_parser, It, Se>);
+        static_assert(x4::parse("", minimal_binary_unused_parser{}, unused));
+        static_assert(x4::parse("", minimal_binary_unused_parser{} > minimal_binary_unused_parser{}, unused));
+    }
+
+    {
+        using It = std::counted_iterator<char const*>;
+        using Se = std::default_sentinel_t;
+        static_assert(std::forward_iterator<It>);
+        static_assert(std::sentinel_for<Se, It>);
+
+        static_assert(x4::X4Subject<minimal_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_parser>);
+        static_assert(x4::is_parsable_v<minimal_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_parser, It, Se>);
+        static_assert(x4::parse("", minimal_parser{}, unused));
+        static_assert(x4::parse("", minimal_parser{} > minimal_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_unary_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_unary_parser>);
+        static_assert(x4::is_parsable_v<minimal_unary_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_unary_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_unary_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_unary_parser, It, Se>);
+        static_assert(x4::parse("", minimal_unary_parser{}, unused));
+        static_assert(x4::parse("", minimal_unary_parser{} > minimal_unary_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_binary_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_binary_parser>);
+        static_assert(x4::is_parsable_v<minimal_binary_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_binary_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_binary_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_binary_parser, It, Se>);
+        static_assert(x4::parse("", minimal_binary_parser{}, unused));
+        static_assert(x4::parse("", minimal_binary_parser{} > minimal_binary_parser{}, unused));
+
+
+        static_assert(x4::X4Subject<minimal_unused_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_unused_parser>);
+        static_assert(x4::is_parsable_v<minimal_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_unused_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_unused_parser, It, Se>);
+        static_assert(x4::parse("", minimal_unused_parser{}, unused));
+        static_assert(x4::parse("", minimal_unused_parser{} > minimal_unused_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_unary_unused_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_unary_unused_parser>);
+        static_assert(x4::is_parsable_v<minimal_unary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_unary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_unary_unused_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_unary_unused_parser, It, Se>);
+        static_assert(x4::parse("", minimal_unary_unused_parser{}, unused));
+        static_assert(x4::parse("", minimal_unary_unused_parser{} > minimal_unary_unused_parser{}, unused));
+
+        static_assert(x4::X4Subject<minimal_binary_unused_parser>);
+        static_assert(x4::X4ExplicitSubject<minimal_binary_unused_parser>);
+        static_assert(x4::is_parsable_v<minimal_binary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(!x4::is_nothrow_parsable_v<minimal_binary_unused_parser, It, Se, unused_type, unused_type>);
+        static_assert(x4::X4Parser<minimal_binary_unused_parser, It, Se>);
+        static_assert(x4::X4ExplicitParser<minimal_binary_unused_parser, It, Se>);
+        static_assert(x4::parse("", minimal_binary_unused_parser{}, unused));
+        static_assert(x4::parse("", minimal_binary_unused_parser{} > minimal_binary_unused_parser{}, unused));
+    }
+
+    return boost::report_errors();
+}

--- a/test/x4/plus.cpp
+++ b/test/x4/plus.cpp
@@ -79,13 +79,13 @@ int main()
 
     {
         std::vector<int> v;
-        BOOST_TEST(parse("123 456 789 10", +int_, v, space) && 4 == v.size() &&
+        BOOST_TEST(parse("123 456 789 10", +int_, space, v) && 4 == v.size() &&
             v[0] == 123 && v[1] == 456 && v[2] == 789 &&  v[3] == 10);
     }
 
     {
         std::vector<std::string> v;
-        BOOST_TEST(parse("a b c d", +lexeme[+alpha], v, space) && 4 == v.size() &&
+        BOOST_TEST(parse("a b c d", +lexeme[+alpha], space, v) && 4 == v.size() &&
             v[0] == "a" && v[1] == "b" && v[2] == "c" &&  v[3] == "d");
     }
 

--- a/test/x4/raw.cpp
+++ b/test/x4/raw.cpp
@@ -53,7 +53,7 @@ int main()
         std::string str;
         BOOST_TEST(parse("spirit_test_123", raw[alpha >> *(alnum | '_')], range));
         BOOST_TEST((std::string(range.begin(), range.end()) == "spirit_test_123"));
-        BOOST_TEST(parse("  spirit", raw[*alpha], range, space));
+        BOOST_TEST(parse("  spirit", raw[*alpha], space, range));
         BOOST_TEST((range.size() == 6));
     }
 

--- a/test/x4/repeat.cpp
+++ b/test/x4/repeat.cpp
@@ -144,7 +144,7 @@ int main()
 
     {
         std::vector<std::string> v;
-        BOOST_TEST(parse("a b c d", repeat(4)[lexeme[+alpha]], v, space) && 4 == v.size() &&
+        BOOST_TEST(parse("a b c d", repeat(4)[lexeme[+alpha]], space, v) && 4 == v.size() &&
             v[0] == "a" && v[1] == "b" && v[2] == "c" &&  v[3] == "d");
     }
     {
@@ -154,7 +154,7 @@ int main()
 
     {
         std::vector<int> v;
-        BOOST_TEST(parse("1 2 3", int_ >> repeat(2)[int_], v, space));
+        BOOST_TEST(parse("1 2 3", int_ >> repeat(2)[int_], space, v));
         BOOST_TEST(v.size() == 3 && v[0] == 1 && v[1] == 2 && v[2] == 3);
 
         BOOST_TEST(!parse("1 2", int_ >> repeat(2)[int_], space));

--- a/test/x4/rule1.cpp
+++ b/test/x4/rule1.cpp
@@ -25,7 +25,6 @@ int main()
     using x4::rule;
     using x4::lit;
     using x4::int_;
-    using x4::unused_type;
     using x4::phrase_parse;
     using x4::root_skipper_flag;
     using x4::traits::has_attribute_v;

--- a/test/x4/rule2.cpp
+++ b/test/x4/rule2.cpp
@@ -25,7 +25,6 @@ int main()
     using namespace x4::standard;
     using x4::rule;
     using x4::lit;
-    using x4::unused_type;
     using x4::_attr;
 
     { // context tests

--- a/test/x4/rule2.cpp
+++ b/test/x4/rule2.cpp
@@ -14,31 +14,11 @@
 #include <boost/spirit/x4/operator/sequence.hpp>
 #include <boost/spirit/x4/operator/kleene.hpp>
 
+#include <concepts>
 #include <iterator>
 #include <string>
 #include <cstring>
 #include <type_traits>
-
-namespace x4 = boost::spirit::x4;
-
-struct check_no_rule_injection_parser
-    : x4::parser<check_no_rule_injection_parser>
-{
-    using attribute_type = x4::unused_type;
-
-    static constexpr bool has_attribute = false;
-
-    template <
-        std::forward_iterator It, std::sentinel_for<It> Se,
-        typename Context, typename RContext, typename Attribute
-    >
-    [[nodiscard]] constexpr bool
-    parse(It&, Se const&, Context const&, RContext const&, Attribute&) const
-    {
-        static_assert(std::is_same_v<Context, x4::parse_context_for<std::string_view>>, "no rule definition injection should occur");
-        return true;
-    }
-} const check_no_rule_injection{};
 
 int main()
 {
@@ -125,11 +105,6 @@ int main()
             BOOST_TEST(parse("abcdef", r[f]));
             BOOST_TEST(s == "abcdef");
         }
-    }
-
-    {
-        BOOST_TEST(parse("", rule<class a>{} = check_no_rule_injection));
-        BOOST_TEST(parse("", rule<class a>{} %= check_no_rule_injection));
     }
 
     return boost::report_errors();

--- a/test/x4/rule3.cpp
+++ b/test/x4/rule3.cpp
@@ -108,7 +108,6 @@ int main()
     using x4::rule;
     using x4::lit;
     using x4::eps;
-    using x4::unused_type;
     using x4::_val;
     using x4::_attr;
 

--- a/test/x4/rule_separate_tu.cpp
+++ b/test/x4/rule_separate_tu.cpp
@@ -8,11 +8,17 @@
 
 #include "rule_separate_tu_grammar.hpp"
 
+#include <concepts>
+#include <utility>
+#include <type_traits>
+
+namespace {
+
 namespace sem_act {
 
 namespace x4 = boost::spirit::x4;
 
-auto nop = [](auto const&){};
+constexpr auto nop = [](auto const&) {};
 
 x4::rule<class used_attr1_r, int> used_attr1;
 auto const used_attr1_def = used_attr::grammar[nop];
@@ -30,7 +36,9 @@ x4::rule<class unused_attr2_r> unused_attr2;
 auto const unused_attr2_def = unused_attr::grammar[nop];
 BOOST_SPIRIT_X4_DEFINE(unused_attr2);
 
-}
+} // sem_act
+
+} // anonymous
 
 int main()
 {
@@ -45,7 +53,7 @@ int main()
     {
         long i;
         static_assert(
-            !std::is_same_v<decltype(i), used_attr::grammar_type::attribute_type>,
+            !std::same_as<decltype(i), used_attr::grammar_type::attribute_type>,
             "ensure we have instantiated the rule with a different attribute type"
         );
         BOOST_TEST(parse("123", used_attr::grammar, i));
@@ -57,8 +65,37 @@ int main()
     {
         long i;
         BOOST_TEST(parse("123", sem_act::used_attr1, i));
+    }
+    {
+        using Context = x4::context<
+            x4::expectation_failure_tag,
+            std::optional<x4::expectation_failure<std::string_view::const_iterator>>,
+            x4::owning_context<
+                x4::context<
+                    x4::rule_val_context_tag,
+                    int
+                >
+            >
+        >;
+        using RuleAgnosticContext = x4::context<
+            x4::expectation_failure_tag,
+            std::optional<x4::expectation_failure<std::string_view::const_iterator>>
+        >;
+
+        static_assert(std::same_as<
+            std::remove_cvref_t<decltype(
+                x4::remove_first_context<x4::rule_val_context_tag>(std::declval<Context const&>())
+            )>,
+            RuleAgnosticContext
+        >);
+
+        long i;
         BOOST_TEST(parse("===", sem_act::used_attr2, i));
+    }
+    {
         BOOST_TEST(parse("123", sem_act::unused_attr1));
+    }
+    {
         BOOST_TEST(parse("===", sem_act::unused_attr2));
     }
 

--- a/test/x4/rule_separate_tu.cpp
+++ b/test/x4/rule_separate_tu.cpp
@@ -69,7 +69,7 @@ int main()
     {
         using Context = x4::context<
             x4::expectation_failure_tag,
-            std::optional<x4::expectation_failure<std::string_view::const_iterator>>,
+            x4::expectation_failure<std::string_view::const_iterator>,
             x4::owning_context<
                 x4::context<
                     x4::rule_val_context_tag,
@@ -79,7 +79,7 @@ int main()
         >;
         using RuleAgnosticContext = x4::context<
             x4::expectation_failure_tag,
-            std::optional<x4::expectation_failure<std::string_view::const_iterator>>
+            x4::expectation_failure<std::string_view::const_iterator>
         >;
 
         static_assert(std::same_as<

--- a/test/x4/rule_separate_tu.cpp
+++ b/test/x4/rule_separate_tu.cpp
@@ -58,7 +58,7 @@ int main()
         );
         BOOST_TEST(parse("123", used_attr::grammar, i));
         BOOST_TEST_EQ(i, 123);
-        BOOST_TEST(parse(" 42", used_attr::grammar, i, used_attr::skipper));
+        BOOST_TEST(parse(" 42", used_attr::grammar, used_attr::skipper, i));
         BOOST_TEST_EQ(i, 42);
     }
 

--- a/test/x4/rule_separate_tu_grammar.cpp
+++ b/test/x4/rule_separate_tu_grammar.cpp
@@ -8,7 +8,10 @@
 
 #include "rule_separate_tu_grammar.hpp"
 
-#include <boost/spirit/x4.hpp>
+#include <boost/spirit/x4/char/char.hpp>
+#include <boost/spirit/x4/char/char_class.hpp>
+#include <boost/spirit/x4/numeric/int.hpp>
+#include <boost/spirit/x4/operator/kleene.hpp>
 
 namespace unused_attr {
 

--- a/test/x4/rule_separate_tu_grammar.hpp
+++ b/test/x4/rule_separate_tu_grammar.hpp
@@ -26,7 +26,7 @@ const skipper_type skipper;
 BOOST_SPIRIT_X4_DECLARE(skipper_type)
 
 // the `unused_type const` must have the same effect as no attribute
-using skipper2_type = x4::rule<class skipper2_r, x4::unused_type const>;
+using skipper2_type = x4::rule<class skipper2_r, unused_type const>;
 const skipper2_type skipper2;
 BOOST_SPIRIT_X4_DECLARE(skipper2_type)
 

--- a/test/x4/rule_separate_tu_grammar.hpp
+++ b/test/x4/rule_separate_tu_grammar.hpp
@@ -14,13 +14,13 @@
 #include <boost/spirit/x4/rule.hpp>
 
 // Check that `BOOST_SPIRIT_X4_INSTANTIATE` instantiates `parse_rule` with proper
-// types when a rule has no attribute.
+// types when the rule has no attribute.
 
 namespace unused_attr {
 
 namespace x4 = boost::spirit::x4;
 
-// skipper must has no attribute, checks `parse` and `skip_over`
+// skipper must have no attribute, check `parse` and `skip_over`
 using skipper_type = x4::rule<class skipper_r>;
 const skipper_type skipper;
 BOOST_SPIRIT_X4_DECLARE(skipper_type)
@@ -30,14 +30,14 @@ using skipper2_type = x4::rule<class skipper2_r, x4::unused_type const>;
 const skipper2_type skipper2;
 BOOST_SPIRIT_X4_DECLARE(skipper2_type)
 
-// grammar must has no attribute, checks `parse` and `phrase_parse`
+// grammar must have no attribute, check `parse` and `phrase_parse`
 using grammar_type = x4::rule<class grammar_r>;
 const grammar_type grammar;
 BOOST_SPIRIT_X4_DECLARE(grammar_type)
 
 }
 
-// Check instantiation when rule has an attribute.
+// Check instantiation when the rule has an attribute.
 
 namespace used_attr {
 

--- a/test/x4/seek.cpp
+++ b/test/x4/seek.cpp
@@ -49,7 +49,7 @@ int main()
         int i = 0;
 
         BOOST_TEST(
-            parse("!@#$%^&* KEY : 123", x4::seek[x4::lit("KEY") >> ':'] >> x4::int_, i, x4::space)
+            parse("!@#$%^&* KEY : 123", x4::seek[x4::lit("KEY") >> ':'] >> x4::int_, x4::space, i)
             && i == 123
         );
     }

--- a/test/x4/sequence.cpp
+++ b/test/x4/sequence.cpp
@@ -37,8 +37,6 @@ int main()
     namespace x4 = boost::spirit::x4;
     namespace traits = x4::traits;
 
-    using x4::unused_type;
-
     using x4::standard::char_;
     using x4::standard::space;
     using x4::standard::string;
@@ -109,7 +107,7 @@ int main()
 
     {
         vector<char, char, char> vec;
-        BOOST_TEST(parse(" a\n  b\n  c", char_ >> char_ >> char_, vec, space));
+        BOOST_TEST(parse(" a\n  b\n  c", char_ >> char_ >> char_, space, vec));
         BOOST_TEST((at_c<0>(vec) == 'a'));
         BOOST_TEST((at_c<1>(vec) == 'b'));
         BOOST_TEST((at_c<2>(vec) == 'c'));
@@ -134,7 +132,7 @@ int main()
     {
         // "hello" has an unused_type. unused attributes are not part of the sequence
         vector<char, char> vec;
-        BOOST_TEST(parse("a hello c", char_ >> "hello" >> char_, vec, space));
+        BOOST_TEST(parse("a hello c", char_ >> "hello" >> char_, space, vec));
         BOOST_TEST((at_c<0>(vec) == 'a'));
         BOOST_TEST((at_c<1>(vec) == 'c'));
     }
@@ -418,7 +416,7 @@ int main()
 
         auto r = *int_;
 
-        BOOST_TEST(parse("123 456", r, vec, space));
+        BOOST_TEST(parse("123 456", r, space, vec));
         BOOST_TEST(at_c<0>(vec).size() == 2);
         BOOST_TEST(at_c<0>(vec)[0] == 123);
         BOOST_TEST(at_c<0>(vec)[1] == 456);
@@ -446,7 +444,7 @@ int main()
         auto const term = rule<class term_id, Attr>("term") = int_ | float_;
         auto const expr = rule<class expr_id, Attr>("expr") = term | ('(' > term > ')');
         Attr var;
-        BOOST_TEST(parse("(1)", expr, var, space));
+        BOOST_TEST(parse("(1)", expr, space, var));
     }
 
     // test that failing sequence leaves attribute consistent

--- a/test/x4/symbols1.cpp
+++ b/test/x4/symbols1.cpp
@@ -150,7 +150,10 @@ int main()
         ;
 
         int i;
-        auto f = [&](auto& ctx){ i = _attr(ctx); };
+        auto f = [&](auto& ctx){ i = _attr(ctx); }; // lambda with capture (important for subsequent checks)
+
+        using Parser = std::remove_cvref_t<decltype(sym[f])>;
+        static_assert(x4::X4ExplicitSubject<Parser>);
 
         BOOST_TEST(parse("Joel", sym[f]));
         BOOST_TEST(i == 1);

--- a/test/x4/test.hpp
+++ b/test/x4/test.hpp
@@ -26,6 +26,9 @@
 
 namespace x4 = boost::spirit::x4;
 
+using x4::unused_type;
+using x4::unused;
+
 namespace spirit_test
 {
     namespace detail
@@ -72,7 +75,7 @@ namespace spirit_test
             static constexpr x4::parse_result<It, Se>
             operator()(It first, Se last, Parser&& p, Skipper&& s, x4::root_skipper_flag flag = x4::root_skipper_flag::do_post_skip)
             {
-                return x4::parse(first, last, std::forward<Parser>(p), x4::unused, std::forward<Skipper>(s), flag);
+                return x4::parse(first, last, std::forward<Parser>(p), std::forward<Skipper>(s), x4::unused, flag);
             }
 
             // parse_result + It/Se + Parser + Skipper
@@ -80,7 +83,7 @@ namespace spirit_test
             static constexpr void
             operator()(x4::parse_result<It, Se>& res, It first, Se last, Parser&& p, Skipper&& s, x4::root_skipper_flag flag = x4::root_skipper_flag::do_post_skip)
             {
-                return x4::parse(res, first, last, std::forward<Parser>(p), x4::unused, std::forward<Skipper>(s), flag);
+                return x4::parse(res, first, last, std::forward<Parser>(p), std::forward<Skipper>(s), x4::unused, flag);
             }
 
             // R + Parser + Skipper
@@ -92,7 +95,7 @@ namespace spirit_test
             static constexpr x4::parse_result_for<R>
             operator()(R const& r, Parser&& p, Skipper&& s, x4::root_skipper_flag flag = x4::root_skipper_flag::do_post_skip)
             {
-                return x4::parse(r, std::forward<Parser>(p), x4::unused, std::forward<Skipper>(s), flag);
+                return x4::parse(r, std::forward<Parser>(p), std::forward<Skipper>(s), x4::unused, flag);
             }
 
             // parse_result + R + Parser + Skipper
@@ -104,7 +107,7 @@ namespace spirit_test
             static constexpr void
             operator()(x4::parse_result_for<R>& res, R const& r, Parser&& p, Skipper&& s, x4::root_skipper_flag flag = x4::root_skipper_flag::do_post_skip)
             {
-                return x4::parse(res, r, std::forward<Parser>(p), x4::unused, std::forward<Skipper>(s), flag);
+                return x4::parse(res, r, std::forward<Parser>(p), std::forward<Skipper>(s), x4::unused, flag);
             }
         }; // parse_overload
 

--- a/test/x4/test.hpp
+++ b/test/x4/test.hpp
@@ -152,10 +152,10 @@ namespace spirit_test
         static constexpr bool has_attribute = true;
         static constexpr bool handles_container = false;
 
-        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename RContext, typename Attribute>
+        template <std::forward_iterator It, std::sentinel_for<It> Se, typename Context, typename Attribute>
         [[nodiscard]] constexpr bool parse(
             It& iter, Se const& last, Context const&,
-            RContext&, Attribute& attr
+            Attribute& attr
         ) const
         {
             if (iter != last && *iter == 's') {

--- a/test/x4/unused.cpp
+++ b/test/x4/unused.cpp
@@ -22,8 +22,6 @@ int main()
     namespace traits = x4::traits;
     using traits::Transformable;
     using traits::transform_attribute;
-    using x4::unused_type;
-    using x4::unused;
     using x4::unused_container_type;
     using x4::unused_container;
 

--- a/test/x4/with.cpp
+++ b/test/x4/with.cpp
@@ -144,7 +144,7 @@ int main()
     {
         // injecting non-const lvalue into the context
         int val = 0;
-        auto const r  = int_[([](auto& ctx){
+        auto const r = int_[([](auto& ctx){
             x4::get<my_tag>(ctx) += x4::_attr(ctx);
         })];
         BOOST_TEST(parse("123,456", with<my_tag>(val)[r % ',']));


### PR DESCRIPTION
Resolves #11

## Motivation (#11)

In pre-X4 codebase, we had the extraneous `rcontext` parameter on every `.parse(...)` invocation for ALL parsers, and we had inserted it to the `_val` context on `action`'s scope. However, as described in #11, that strategy has significant drawbacks.

This PR removes the common `rcontext` param on X4; now we simply append the rule attribute reference to the `context`, as it can essentially work as the global storage for any parsers. The new strategy is to insert or replace the `_val` context in `rule`'s scope (i.e., not `action`'s scope).

## Backgrounds

After a historical research, it turned out that Joel has had experimented with something similar to this strategy on 2013 (ref: https://github.com/boostorg/spirit/commit/e2e18c5931611edd1bc4c471f0dcf756b1085794, CC: @djowel). Surprisingly, at that time, we actually didn't have that global `rcontext` parameter at all. Joel's original approach was setting the rule context as a **pointer** value, which enables dynamic replacement, I guess.

However, due to some unobvious reasons, the implementation has evolved over time, resulting in the complete different approach (i.e., the `rcontext` parameter) we have had in X3.

## This PR's strategy

Key changes: 

- `x4/rule.hpp`
- `x4/core/context.hpp`

This PR implements new `x4::replace_first_context` function that replaces the `_val` reference bound to the `context` (note: not to be confused with `rcontext`). At first, this seemed enough to implement the suggested change, but it turned out that the naive implementation inevitably creates a different context type (of course) for arbitrary grammar composition, which destroyed the usage of `BOOST_SPIRIT_X4_INSTANTIATE`.

The final solution is to implement additional utility, `x4::remove_first_context`, to strip the `_val` context already bound to the **recursive** invocation of rules. That way we always have the same (rule-agnostic) context type which can be passed to `BOOST_SPIRIT_X4_INSTANTIATE`, and we still can construct the _real_ `_val` context inside `call_rule_definition`.

## Note about the lifetime of rule attribute

Although the `context` acts like the "global" storage, the actual lifetime of the rule-specific attribute is managed by stack-like structure, similar to that of `x4::locals`. Note that we don't actually use `x4::locals` here; we *already have* the stack-like structure because a recursive grammar inherently creates the nested invocation hierarchy, which ultimately does the same thing.