### PR TITLE
Fix the "Spirit X3 rule problem"

### DIFF
--- a/include/boost/spirit/x4/core/parser.hpp
+++ b/include/boost/spirit/x4/core/parser.hpp
@@ -42,8 +42,8 @@ namespace boost::spirit::x4
 
     template <typename T>
     concept X4Attribute =
-        std::is_same_v<std::remove_const_t<T>, unused_type> ||
-        std::is_same_v<std::remove_const_t<T>, unused_container_type> ||
+        std::same_as<std::remove_const_t<T>, unused_type> ||
+        std::same_as<std::remove_const_t<T>, unused_container_type> ||
         (
             std::is_object_v<T> && // implies not reference
             !std::is_base_of_v<detail::parser_base, std::remove_const_t<T>> &&

--- a/include/boost/spirit/x4/parse.hpp
+++ b/include/boost/spirit/x4/parse.hpp
@@ -117,10 +117,10 @@ namespace boost::spirit::x4
             // parse(range)
 
             // R + Parser + Attribute
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4Attribute ParseAttr>
                 requires (!traits::CharArray<R>)
             static constexpr parse_result_for<R>
-            operator()(R const& range, Parser&& p, Attr& attr)
+            operator()(R const& range, Parser&& p, ParseAttr& attr)
             {
                 using It = std::ranges::iterator_t<R const>;
                 using Se = std::ranges::sentinel_t<R const>;
@@ -129,6 +129,7 @@ namespace boost::spirit::x4
 
                 It first = std::ranges::begin(range);
                 Se last = std::ranges::end(range);
+
                 bool const ok = as_parser(std::forward<Parser>(p)).parse(
                     first, last,
                     x4::make_context<expectation_failure_tag>(expect_failure),
@@ -142,10 +143,10 @@ namespace boost::spirit::x4
             }
 
             // parse_result + R + Parser + Attribute
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4Attribute ParseAttr>
                 requires (!traits::CharArray<R>)
             static constexpr void
-            operator()(parse_result_for<R>& res, R const& range, Parser&& p, Attr& attr)
+            operator()(parse_result_for<R>& res, R const& range, Parser&& p, ParseAttr& attr)
             {
                 using It = std::ranges::iterator_t<R const>;
                 using Se = std::ranges::sentinel_t<R const>;
@@ -162,17 +163,17 @@ namespace boost::spirit::x4
             }
 
             // "str" + Parser + Attribute
-            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4Attribute ParseAttr>
             static constexpr parse_result_for<R>
-            operator()(R const& str, Parser&& p, Attr& attr)
+            operator()(R const& str, Parser&& p, ParseAttr& attr)
             {
                 return parse_fn_main::operator()(std::basic_string_view{str}, std::forward<Parser>(p), attr);
             }
 
             // parse_result + "str" + Parser + Attribute
-            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4Attribute Attr>
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4Attribute ParseAttr>
             static constexpr void
-            operator()(parse_result_for<R>& res, R const& str, Parser&& p, Attr& attr)
+            operator()(parse_result_for<R>& res, R const& str, Parser&& p, ParseAttr& attr)
             {
                 return parse_fn_main::operator()(res, std::basic_string_view{str}, std::forward<Parser>(p), attr);
             }
@@ -181,10 +182,10 @@ namespace boost::spirit::x4
             // phrase_parse(range)
 
             // R + Parser + Skipper + Attribute + (root_skipper_flag)
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute ParseAttr>
                 requires (!traits::CharArray<R>)
             static constexpr parse_result_for<R>
-            operator()(R const& range, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(R const& range, Parser&& p, Skipper const& s, ParseAttr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
                 using It = std::ranges::iterator_t<R const>;
                 using Se = std::ranges::sentinel_t<R const>;
@@ -211,10 +212,10 @@ namespace boost::spirit::x4
             }
 
             // parse_result + R + Parser + Skipper + Attribute
-            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+            template <std::ranges::forward_range R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute ParseAttr>
                 requires (!traits::CharArray<R>)
             static constexpr void
-            operator()(parse_result_for<R>& res, R const& range, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(parse_result_for<R>& res, R const& range, Parser&& p, Skipper const& s, ParseAttr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
                 using It = std::ranges::iterator_t<R const>;
                 using Se = std::ranges::sentinel_t<R const>;
@@ -236,17 +237,17 @@ namespace boost::spirit::x4
             }
 
             // "str" + Parser + Skipper + Attribute + (root_skipper_flag)
-            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute ParseAttr>
             static constexpr parse_result_for<R>
-            operator()(R const& str, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(R const& str, Parser&& p, Skipper const& s, ParseAttr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
                 return parse_fn_main::operator()(std::basic_string_view{str}, std::forward<Parser>(p), s, attr, flag);
             }
 
             // parse_result + "str" + Parser + Attribute + Skipper
-            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute Attr>
+            template <traits::CharArray R, X4RangeParseParser<R> Parser, X4RangeParseSkipper<R> Skipper, X4Attribute ParseAttr>
             static constexpr void
-            operator()(parse_result_for<R>& res, R const& str, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(parse_result_for<R>& res, R const& str, Parser&& p, Skipper const& s, ParseAttr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
                 return parse_fn_main::operator()(res, std::basic_string_view{str}, std::forward<Parser>(p), s, attr, flag);
             }
@@ -255,9 +256,9 @@ namespace boost::spirit::x4
             // parse(it/se)
 
             // It/Se + Parser + Attribute
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4Attribute Attr>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4Attribute ParseAttr>
             static constexpr parse_result<It, Se>
-            operator()(It first, Se last, Parser&& p, Attr& attr)
+            operator()(It first, Se last, Parser&& p, ParseAttr& attr)
             {
                 expectation_failure<It> expect_failure;
                 bool const ok = as_parser(std::forward<Parser>(p)).parse(
@@ -273,9 +274,9 @@ namespace boost::spirit::x4
             }
 
             // parse_result + It/Se + Parser + Attribute
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4Attribute Attr>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4Attribute ParseAttr>
             static constexpr void
-            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, Attr& attr)
+            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, ParseAttr& attr)
             {
                 res.expect_failure.clear();
                 res.ok = as_parser(std::forward<Parser>(p)).parse(
@@ -290,9 +291,9 @@ namespace boost::spirit::x4
             // phrase_parse(it/se)
 
             // It/Se + Parser + Skipper + Attribute + (root_skipper_flag)
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper, X4Attribute Attr>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper, X4Attribute ParseAttr>
             static constexpr parse_result<It, Se>
-            operator()(It first, Se last, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(It first, Se last, Parser&& p, Skipper const& s, ParseAttr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
                 auto const skipper_ctx = x4::make_context<skipper_tag>(s);
 
@@ -314,9 +315,9 @@ namespace boost::spirit::x4
             }
 
             // parse_result + It/Se + Parser + Skipper + Attribute + (root_skipper_flag)
-            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper, X4Attribute Attr>
+            template <std::forward_iterator It, std::sentinel_for<It> Se, X4Parser<It, Se> Parser, X4ExplicitParser<It, Se> Skipper, X4Attribute ParseAttr>
             static constexpr void
-            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, Skipper const& s, Attr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
+            operator()(parse_result<It, Se>& res, It first, Se last, Parser&& p, Skipper const& s, ParseAttr& attr, root_skipper_flag flag = root_skipper_flag::do_post_skip)
             {
                 auto const skipper_ctx = x4::make_context<skipper_tag>(s);
 

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -102,6 +102,7 @@ x4_define_tests(
     uint_radix
     unused
     with
+    x3_rule_problem
 )
 
 x4_define_test(rule_separate_tu rule_separate_tu.cpp rule_separate_tu_grammar.cpp)

--- a/test/x4/Jamfile
+++ b/test/x4/Jamfile
@@ -60,6 +60,7 @@ rule compile-fail ( sources + : requirements * : target-name ? )
 
 run parser.cpp ;
 run context.cpp ;
+run x3_rule_problem.cpp ;
 
 run actions.cpp ;
 run alternative.cpp ;

--- a/test/x4/x3_rule_problem.cpp
+++ b/test/x4/x3_rule_problem.cpp
@@ -1,0 +1,68 @@
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "test.hpp"
+
+#include <boost/spirit/x4/rule.hpp>
+
+#include <vector>
+#include <set>
+
+int main()
+{
+    enum class strong_int : int {};
+
+    // Primitive (int)
+    {
+        using It = std::string_view::const_iterator;
+        using Se = It;
+        using Rule = x4::rule<struct my_rule, int>;
+
+        static_assert(x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, int>);
+        static_assert(x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, long long>);
+
+        // Narrowing conversion
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, short>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, unsigned long long>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, double>);
+
+        // Not permitted as of now, but can be relaxed in the future
+        static_assert(!x4::detail::RuleAttrTransformable<strong_int, int>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, strong_int>);
+    }
+
+    // Primitive (double)
+    {
+        using It = std::string_view::const_iterator;
+        using Se = It;
+        using Rule = x4::rule<struct my_rule, double>;
+
+        static_assert(x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, double>);
+        static_assert(x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, long double>);
+
+        // Narrowing conversion
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, int>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, long long>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, unsigned long long>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, float>);
+    }
+
+    // "The Spirit X3 rule problem" in Boost.Parser's documentation
+    // https://www.boost.org/doc/libs/1_89_0/doc/html/boost_parser/this_library_s_relationship_to_boost_spirit.html#boost_parser.this_library_s_relationship_to_boost_spirit.the_spirit_x3_rule_problem
+    // https://github.com/boostorg/spirit_x4/issues/38
+    {
+        using It = std::string_view::const_iterator;
+        using Se = It;
+        using Rule = x4::rule<struct my_rule, std::vector<int>>;
+
+        static_assert(x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, std::vector<int>>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, std::set<int>>);
+        static_assert(!x4::is_parsable_v<Rule, It, Se, x4::parse_context_for<It, Se>, std::vector<strong_int>>);
+    }
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
Part of #4 
Fixes #38

<https://www.boost.org/doc/libs/1_89_0/doc/html/boost_parser/this_library_s_relationship_to_boost_spirit.html#boost_parser.this_library_s_relationship_to_boost_spirit.the_spirit_x3_rule_problem>

After some discussion with @yaito3014, we found that the problem can be simply resolved by prohibiting implicit conversion on rule attributes.

In X3 codebase we had zero unit tests that _permits_ this conversion, so it can be assumed that we still have backward compatibility in Spirit's semantics, even after this fix.