### PR TITLE
Improve `context` to make it capable of holding both lvalue/rvalue

### DIFF
--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -14,16 +14,39 @@
 
 namespace boost::spirit::x4 {
 
-struct parse_pass_context_tag; // _pass
+namespace contexts {
 
-// _val
-struct rule_val_context_tag
+// _pass
+struct parse_pass
 {
     static constexpr bool is_unique = true;
 };
 
-struct where_context_tag; // _where
-struct attr_context_tag; // _attr
+// _val
+struct rule_val
+{
+    static constexpr bool is_unique = true;
+};
+
+// _where
+struct where
+{
+    static constexpr bool is_unique = true;
+};
+
+// _attr
+struct attr
+{
+    static constexpr bool is_unique = true;
+};
+
+} // contexts
+
+using parse_pass_context_tag [[deprecated("Use `x4::contexts::parse_pass`")]] = contexts::parse_pass;
+using rule_val_context_tag [[deprecated("Use `x4::contexts::rule_val`")]] = contexts::rule_val;
+using where_context_tag [[deprecated("Use `x4::contexts::where`")]] = contexts::where;
+using attr_context_tag [[deprecated("Use `x4::contexts::attr`")]] = contexts::attr;
+
 
 namespace detail {
 
@@ -33,7 +56,7 @@ struct _pass_fn
     [[nodiscard]] static constexpr bool&
     operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
     {
-        return x4::get<parse_pass_context_tag>(ctx);
+        return x4::get<contexts::parse_pass>(ctx);
     }
 
     template<class Context>
@@ -46,7 +69,7 @@ struct _val_fn
     [[nodiscard]] static constexpr auto&&
     operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
     {
-        return x4::get<rule_val_context_tag>(ctx);
+        return x4::get<contexts::rule_val>(ctx);
     }
 
     template<class Context>
@@ -59,7 +82,7 @@ struct _where_fn
     [[nodiscard]] static constexpr auto&&
     operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
     {
-        return x4::get<where_context_tag>(ctx);
+        return x4::get<contexts::where>(ctx);
     }
 
     template<class Context>
@@ -72,7 +95,7 @@ struct _attr_fn
     [[nodiscard]] static constexpr auto&&
     operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
     {
-        return x4::get<attr_context_tag>(ctx);
+        return x4::get<contexts::attr>(ctx);
     }
 
     template<class Context>

--- a/include/boost/spirit/x4/core/context.hpp
+++ b/include/boost/spirit/x4/core/context.hpp
@@ -30,29 +30,6 @@ using monostate_context = context<monostate_context_tag, void, unused_type>;
 
 } // detail
 
-template<class ContextT>
-struct owning_context; // not defined
-
-template<class ID, class T, class Next>
-struct owning_context<context<ID, T, Next>> {};
-
-
-// TODO: Rename. `get` is too generic name.
-template<class ID, class Context>
-[[nodiscard]] constexpr decltype(auto)
-get(Context const& ctx) noexcept
-{
-    return ctx.get(std::type_identity<ID>{});
-}
-
-template<class ID, class Context>
-void get(Context const&&) = delete; // dangling
-
-// TODO: check whether auto-completion is available for this current implementation.
-// If not, we should implement a partially specialized metafunction instead.
-template<class ID, class Context>
-using get_context_plain_t = std::remove_cvref_t<decltype(x4::get<ID>(std::declval<Context const&>()))>;
-
 
 template<class Context, class ID_To_Search>
 struct has_context;
@@ -73,168 +50,303 @@ struct has_context<context<ID_To_Search, T, Next>, ID_To_Search>
 template<class ID, class T, class Next, class ID_To_Search>
     requires (!std::same_as<ID, ID_To_Search>)
 struct has_context<context<ID, T, Next>, ID_To_Search>
-    : has_context<Next, ID_To_Search>
+    : has_context<std::remove_cvref_t<Next>, ID_To_Search>
 {};
 
-template<class ContextT, class ID_To_Search>
-struct has_context<owning_context<ContextT>, ID_To_Search>
-    : has_context<ContextT, ID_To_Search>
-{};
+
+template<class ID_To_Get, class ID, class T, class Next>
+[[nodiscard]] constexpr decltype(auto)
+get(context<ID, T, Next> const& ctx) noexcept
+{
+    if constexpr (has_context_v<context<ID, T, Next>, ID_To_Get>) {
+        return ctx.get(std::type_identity<ID_To_Get>{});
+    } else {
+        return (unused); // return lvalue
+    }
+}
+
+template<class ID_To_Get>
+[[nodiscard]] constexpr unused_type const&
+get(unused_type const&) noexcept
+{
+    return unused;
+}
+
+template<class ID_To_Get, class ID, class T, class Next>
+void get(context<ID, T, Next> const&&) = delete; // dangling
+
+template<class ID, class Context>
+using get_context_plain_t = std::remove_cvref_t<decltype(x4::get<ID>(std::declval<Context const&>()))>;
+
 
 template<class Context, class ID, class T>
-struct has_context_of
+struct has_context_of : std::false_type {};
+
+template<class Context, class ID, class T>
+    requires has_context_v<Context, ID>
+struct has_context_of<Context, ID, T>
 {
     static_assert(!std::is_reference_v<T>);
+    static_assert(!std::is_const_v<T>);
     static constexpr bool value = std::same_as<get_context_plain_t<ID, Context>, T>;
 };
 
 template<class Context, class ID, class T>
 constexpr bool has_context_of_v = has_context_of<Context, ID, T>::value;
 
+namespace detail {
 
 template<class ID>
 concept UniqueContextID = !requires { ID::is_unique; } || requires { requires ID::is_unique; };
 
-namespace detail {
+template<class ID>
+concept AllowUnusedContextID = requires { requires ID::allow_unused; };
 
 template<class ID, class Next>
 concept HasNoDuplicateContext = !UniqueContextID<ID> || !has_context_v<Next, ID>;
 
-} // detail
+template<class T>
+concept ContextValueType =
+    !std::same_as<std::remove_cvref_t<T>, unused_type> &&
+    !std::is_reference_v<T> &&
+    !is_ttp_specialization_of_v<std::remove_const_t<T>, context>;
 
-template<class ID, class T, class Next = unused_type>
-struct context
+template<class Next>
+concept ContextNextType =
+    !std::same_as<std::remove_cvref_t<Next>, unused_type> &&
+    (
+        (
+            std::is_lvalue_reference_v<Next> &&
+            std::is_const_v<std::remove_reference_t<Next>>
+        ) ||
+        (
+            !std::is_lvalue_reference_v<Next> &&
+            !std::is_rvalue_reference_v<Next> &&
+            !std::is_const_v<Next> &&
+            std::move_constructible<Next>
+        )
+    );
+
+template<class ContextWithCVRef>
+using canonical_context_t = std::conditional_t<
+    std::same_as<std::remove_cvref_t<ContextWithCVRef>, unused_type>,
+    unused_type,
+    std::conditional_t<
+        std::is_lvalue_reference_v<ContextWithCVRef>,
+        std::remove_reference_t<ContextWithCVRef> const&, // Next& -> Next const&
+        std::remove_cvref_t<ContextWithCVRef> // Next const -> Next
+    >
+>;
+
+template<class ID, class T, class Next>
+struct context_storage
 {
-    static_assert(!std::is_reference_v<T>);
-    static_assert(!is_ttp_specialization_of_v<std::remove_const_t<T>, context>, "context's value type cannot be context");
+    static_assert(ContextValueType<T>);
+    static_assert(ContextNextType<Next>);
 
-    static_assert(!std::is_reference_v<Next>);
-    static_assert(!std::is_const_v<Next>);
-    static_assert(detail::HasNoDuplicateContext<ID, Next>);
-    static_assert(!std::same_as<Next, detail::monostate_context>);
-
-    constexpr context(T& val BOOST_SPIRIT_LIFETIMEBOUND, Next const& next BOOST_SPIRIT_LIFETIMEBOUND) noexcept
+    // lvalue{lvalue} or non-reference{lvalue}
+    constexpr context_storage(T& val BOOST_SPIRIT_LIFETIMEBOUND, std::remove_cvref_t<Next> const& next) noexcept
         : val(val)
         , next(next)
     {}
 
-    context(T&, Next const&&) = delete; // dangling
-    context(std::remove_const_t<T> const&&, Next const&) = delete; // dangling
-    context(std::remove_const_t<T> const&&, Next const&&) = delete; // dangling
+    // non-reference{rvalue}
+    constexpr context_storage(T& val BOOST_SPIRIT_LIFETIMEBOUND, std::remove_cvref_t<Next>&& next)
+        noexcept(std::is_nothrow_constructible_v<Next, std::remove_const_t<Next>>)
+        requires (!std::is_lvalue_reference_v<Next>)
+        : val(val)
+        , next(std::move(next))
+    {}
 
-    constexpr context(context&&) = default;
-    constexpr context& operator=(context&&) = default;
-    constexpr context(context const&) = delete;
-    constexpr context& operator=(context const&) = delete;
+    // non-reference{const rvalue}
+    constexpr context_storage(T& val BOOST_SPIRIT_LIFETIMEBOUND, std::remove_cvref_t<Next> const&& next)
+        noexcept(std::is_nothrow_constructible_v<Next, std::remove_const_t<Next> const>)
+        requires (!std::is_lvalue_reference_v<Next>)
+        : val(val)
+        , next(std::move(next))
+    {}
 
-    [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
+    // lvalue{rvalue}
+    context_storage(std::remove_const_t<T> const&, std::remove_cvref_t<Next> const&&) requires std::is_lvalue_reference_v<Next> = delete;
+    context_storage(std::remove_const_t<T> const&&, std::remove_cvref_t<Next> const&) = delete;
+
+    [[nodiscard]] constexpr T& get(std::type_identity<ID> const&) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
     {
         return val;
     }
 
-    [[nodiscard]] constexpr decltype(auto) get(auto id) const noexcept
+    [[nodiscard]] constexpr decltype(auto) get(auto const& id) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
     {
         return next.get(id);
     }
 
     T& val;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-    Next const& next;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+    BOOST_SPIRIT_NO_UNIQUE_ADDRESS Next next;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+};
+
+template<class ID, class T, class Next>
+    requires std::same_as<std::remove_cvref_t<Next>, unused_type>
+struct context_storage<ID, T, Next>
+{
+    static_assert(ContextValueType<T>);
+
+    constexpr explicit context_storage(T& val BOOST_SPIRIT_LIFETIMEBOUND) noexcept
+        : val(val)
+    {}
+
+    constexpr context_storage(T& val BOOST_SPIRIT_LIFETIMEBOUND, unused_type const&) noexcept
+        : val(val)
+    {}
+
+    context_storage(std::remove_const_t<T> const&&) = delete;
+    context_storage(std::remove_const_t<T> const&&, unused_type const&) = delete;
+
+    [[nodiscard]] constexpr T& get(std::type_identity<ID> const&) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
+    {
+        return val;
+    }
+
+    static void get(auto const&) = delete; // ID not found
+
+    T& val;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+};
+
+#define BOOST_SPIRIT_X4_UNUSED_CONTEXT_VALUE_TYPE_ERROR \
+    "Assigning `unused` to a unique context does not make sense because " \
+    "unique context is binary: it either holds a value or is empty. Introducing " \
+    "`unused` makes it tri-state, which is prohibited for maintainability. If you " \
+    "want to propagate `unused` as a placeholder (e.g. for debug QoL purpose), " \
+    "mark the tag with `allow_unused = true`."
+
+template<class ID, class T, class Next>
+    requires std::same_as<std::remove_const_t<T>, unused_type>
+struct context_storage<ID, T, Next>
+{
+    static_assert(ContextNextType<Next>);
+
+    static_assert(
+        !detail::UniqueContextID<ID> || detail::AllowUnusedContextID<ID>,
+        BOOST_SPIRIT_X4_UNUSED_CONTEXT_VALUE_TYPE_ERROR
+    );
+
+    // lvalue{lvalue} or non-reference{lvalue}
+    constexpr context_storage(unused_type const&, std::remove_cvref_t<Next> const& next) noexcept
+        : next(next)
+    {}
+
+    // non-reference{rvalue}
+    constexpr context_storage(unused_type const&, std::remove_cvref_t<Next>&& next)
+        noexcept(std::is_nothrow_constructible_v<Next, std::remove_cvref_t<Next>>)
+        requires (!std::is_lvalue_reference_v<Next>)
+        : next(std::move(next))
+    {}
+
+    // non-reference{const rvalue}
+    constexpr context_storage(unused_type const&, std::remove_cvref_t<Next> const&& next)
+        noexcept(std::is_nothrow_constructible_v<Next, std::remove_cvref_t<Next> const>)
+        requires (!std::is_lvalue_reference_v<Next>)
+        : next(std::move(next))
+    {}
+
+    // lvalue{rvalue}
+    context_storage(unused_type const&, std::remove_cvref_t<Next> const&&) requires std::is_lvalue_reference_v<Next> = delete;
+
+    [[nodiscard]] static constexpr unused_type const& get(std::type_identity<ID> const&) noexcept
+    {
+        return unused;
+    }
+
+    [[nodiscard]] constexpr decltype(auto) get(auto const& id) const noexcept
+    {
+        return next.get(id);
+    }
+
+    BOOST_SPIRIT_NO_UNIQUE_ADDRESS Next next;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+};
+
+template<class ID, class T, class Next>
+    requires
+        std::same_as<std::remove_const_t<T>, unused_type> &&
+        std::same_as<std::remove_cvref_t<Next>, unused_type>
+struct context_storage<ID, T, Next>
+{
+    static_assert(
+        !detail::UniqueContextID<ID> || detail::AllowUnusedContextID<ID>,
+        BOOST_SPIRIT_X4_UNUSED_CONTEXT_VALUE_TYPE_ERROR
+    );
+
+    constexpr context_storage() noexcept = default;
+    constexpr explicit context_storage(unused_type const&) noexcept {}
+    constexpr context_storage(unused_type const&, unused_type const&) noexcept {}
+
+    [[nodiscard]] static constexpr unused_type const& get(std::type_identity<ID> const&) noexcept
+    {
+        return unused;
+    }
+
+    static void get(auto const&) = delete; // ID not found
+};
+
+#undef BOOST_SPIRIT_X4_UNUSED_CONTEXT_VALUE_TYPE_ERROR
+
+} // detail
+
+template<class ID, class T, class Next = unused_type>
+struct context : detail::context_storage<ID, T, Next>
+{
+private:
+    static_assert(
+        !std::same_as<std::remove_cvref_t<Next>, unused_type> || std::same_as<Next, unused_type>,
+        "Next cannot be a reference to `unused_type`; use plain type instead"
+    );
+    static_assert(!std::same_as<std::remove_cvref_t<Next>, detail::monostate_context>);
+
+    using storage_type = detail::context_storage<ID, T, Next>;
+
+public:
+    static_assert(detail::HasNoDuplicateContext<ID, std::remove_cvref_t<Next>>);
+
+    using value_type = T;
+    using next_type = Next;
+
+    using storage_type::storage_type;
+    // TODO: ^^^ Why is clang-tidy complaining about `Rvalue reference parameter "" is never moved`?
 };
 
 // Empty context specialization. Materialized when `remove_context` removed everything.
-template<>
-struct context<detail::monostate_context_tag, void>
+template<class T>
+struct context<detail::monostate_context_tag, T>
 {
-    [[nodiscard]] static constexpr unused_type const& get(auto) noexcept
-    {
-        return unused;
-    }
+    static_assert(std::is_void_v<T>, "monostate_context's value type must be void");
+
+    using value_type = void;
+    using next_type = unused_type;
+
+    void get(auto const&) = delete;
 };
+
+template<class ID, class T, class Next>
+    requires
+        (!std::same_as<std::remove_cvref_t<Next>, unused_type>) &&
+        (!std::same_as<std::remove_cvref_t<Next>, detail::monostate_context>)
+[[nodiscard]] constexpr context<ID, T, detail::canonical_context_t<Next>>
+make_context(T& val, Next&& next)
+    noexcept(std::is_nothrow_constructible_v<detail::canonical_context_t<Next>, Next>)
+{
+    if constexpr (std::is_lvalue_reference_v<Next>) {
+        // class `context` can only hold const lvalue reference
+        return {val, std::as_const(next)};
+
+    } else {
+        return {val, std::forward<Next>(next)};
+    }
+}
 
 template<class ID, class T>
-struct context<ID, T, unused_type>
+[[nodiscard]] constexpr context<ID, T>
+make_context(T& val, unused_type const&) noexcept
 {
-    static_assert(!std::is_reference_v<T>);
-    static_assert(!is_ttp_specialization_of_v<std::remove_const_t<T>, context>, "context's value type cannot be context");
-
-    constexpr explicit context(T& val BOOST_SPIRIT_LIFETIMEBOUND) noexcept
-        requires (!std::same_as<std::remove_const_t<T>, context>)
-        : val(val)
-    {}
-
-    constexpr context(T& val BOOST_SPIRIT_LIFETIMEBOUND, unused_type) noexcept
-        : val(val)
-    {}
-
-    context(std::remove_const_t<T> const&&) = delete; // dangling
-    context(std::remove_const_t<T> const&&, unused_type) = delete; // dangling
-
-    constexpr context(context&&) = default;
-    constexpr context& operator=(context&&) = default;
-    constexpr context(context const&) = delete;
-    constexpr context& operator=(context const&) = delete;
-
-    [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
-    {
-        return val;
-    }
-
-    [[nodiscard]] static constexpr unused_type const& get(auto) noexcept
-    {
-        return unused;
-    }
-
-    T& val;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-};
-
-template<class ID, class T, class Next>
-struct context<ID, T, owning_context<Next>>
-{
-    static_assert(!std::is_reference_v<T>);
-    static_assert(!is_ttp_specialization_of_v<std::remove_const_t<T>, context>, "context's value type cannot be context");
-    static_assert(!std::same_as<std::remove_const_t<T>, unused_type>, "context holding `unused_type` as `T` is not supported");
-
-    static_assert(!std::is_reference_v<Next>);
-    static_assert(detail::HasNoDuplicateContext<ID, Next>);
-    static_assert(!std::same_as<Next, detail::monostate_context>);
-
-    template<class OwningNext>
-        requires std::is_constructible_v<Next, OwningNext>
-    constexpr context(T& val BOOST_SPIRIT_LIFETIMEBOUND, OwningNext&& owning_next)
-        noexcept(std::is_nothrow_constructible_v<Next, OwningNext>)
-        : val(val)
-        , next(std::forward<OwningNext>(owning_next))
-    {}
-
-    template<class OwningNext>
-        requires std::is_constructible_v<Next, OwningNext>
-    context(std::remove_const_t<T> const&&, OwningNext&&) = delete; // dangling
-
-    constexpr context(context&&) = default;
-    constexpr context& operator=(context&&) = default;
-    constexpr context(context const&) = delete;
-    constexpr context& operator=(context const&) = delete;
-
-    [[nodiscard]] constexpr T& get(std::type_identity<ID>) const noexcept BOOST_SPIRIT_LIFETIMEBOUND
-    {
-        return val;
-    }
-
-    [[nodiscard]] constexpr decltype(auto) get(auto id) const noexcept
-    {
-        return next.get(id);
-    }
-
-    T& val;  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
-    Next next; // not reference
-};
-
-
-template<class ID, class T, class Next>
-[[nodiscard]] constexpr context<ID, T, Next>
-make_context(T& val, Next const& next) noexcept
-{
-    return {val, next};
+    return context<ID, T>{val};
 }
 
 template<class ID, class T>
@@ -244,16 +356,6 @@ make_context(T& val, detail::monostate_context const&) noexcept
     return context<ID, T>{val};
 }
 
-template<class ID, class T, class Next>
-void make_context(T const&&, Next const&) = delete; // dangling
-
-template<class ID, class T, class Next>
-void make_context(T const&&, Next const&&) = delete; // dangling
-
-template<class ID, class T, class Next>
-void make_context(T&, Next const&&) = delete; // dangling
-
-
 template<class ID, class T>
 [[nodiscard]] constexpr context<ID, T>
 make_context(T& val) noexcept
@@ -261,72 +363,12 @@ make_context(T& val) noexcept
     return context<ID, T>{val};
 }
 
+template<class ID, class T, class Next>
+void make_context(T const&&, Next const&) = delete; // dangling
+
 template<class ID, class T>
 void make_context(T const&&) = delete; // dangling
 
-
-// Replaces the contained reference of the leftmost context
-// having the id `ID_To_Replace`. If no such context exists,
-// append a new one.
-//
-// This helper makes it possible to dynamically update the
-// reference bound to the (runtime) context, while avoiding
-// infinite instantiation in recursive grammars.
-//
-// The most notable example of a parser that requires this
-// operation is `x4::locals`. Without this helper, it would
-// inevitably trigger infinite instantiation when binding
-// a local variable instance to the context.
-template<class ID_To_Replace, class ID, class T, class Next, class NewVal>
-[[nodiscard]] constexpr auto
-replace_first_context(
-    context<ID, T, Next> const& ctx,
-    NewVal& new_val BOOST_SPIRIT_LIFETIMEBOUND
-) noexcept
-{
-    static_assert(!is_ttp_specialization_of_v<std::remove_const_t<NewVal>, context>, "context's value type cannot be context");
-    static_assert(!std::same_as<ID_To_Replace, detail::monostate_context_tag>);
-
-    if constexpr (std::same_as<ID, ID_To_Replace>) { // Match
-        if constexpr (std::same_as<Next, unused_type>) {
-            // Existing context found; replace it and end the search.
-            return context<ID, NewVal, Next>{new_val};
-
-        } else {
-            // Existing context found; replace it and end the search.
-            //
-            // This implementation does not replace succeeding (duplicate) entries,
-            // because it is `replace_*first*_context`.
-            return context<ID, NewVal, Next>{new_val, ctx.next};
-        }
-
-    } else { // No match
-        if constexpr (std::same_as<ID, detail::monostate_context_tag>) {
-            // No match at all. Create a brand-new context.
-            return context<ID_To_Replace, NewVal>{new_val};
-
-        } else if constexpr (std::same_as<Next, unused_type>) {
-            // No match at all. Append a new one and return.
-            // Since we're doing the search from left to right,
-            // this branch means there was no existing context
-            // for `ID_To_Replace`.
-            using NewContext = context<ID_To_Replace, NewVal>;
-            return context<ID, T, owning_context<NewContext>>{
-                ctx.val, NewContext{new_val}
-            };
-
-        } else {
-            // No match. Continue the replacement recursively.
-            using NewNext = decltype(x4::replace_first_context<ID_To_Replace>(ctx.next, new_val));
-            return context<ID, T, owning_context<NewNext>>{
-                ctx.val, x4::replace_first_context<ID_To_Replace>(ctx.next, new_val)
-            };
-        }
-    }
-}
-
-template<class ID_To_Replace, class ID, class T, class Next, class NewVal>
-void replace_first_context(context<ID, T, Next> const&, NewVal const&&) = delete; // dangling
 
 // Remove the contained reference of the leftmost context having the id `ID_To_Remove`.
 template<class ID_To_Remove, class ID, class T, class Next>
@@ -367,7 +409,7 @@ remove_first_context(context<ID, T, Next> const& ctx) noexcept
     // For this reason, a "remove" operation on an any context is semantically
     // valid if and only if the ID is unique. In such case, `remove_first_context`
     // is essentially equal to `remove_*all*_context`, which is our intention.
-    static_assert(UniqueContextID<ID_To_Remove>);
+    static_assert(detail::UniqueContextID<ID_To_Remove>);
 
     if constexpr (std::same_as<ID, ID_To_Remove>) { // Match
         if constexpr (std::same_as<Next, unused_type>) {
@@ -377,7 +419,7 @@ remove_first_context(context<ID, T, Next> const& ctx) noexcept
 
         } else {
             // Existing context found; remove it and end the search.
-            return ctx.next;
+            return (ctx.next); // Parenthesis is important
         }
 
     } else { // No match
@@ -389,28 +431,29 @@ remove_first_context(context<ID, T, Next> const& ctx) noexcept
             // No match. Continue the replacement recursively.
             using NewNext = decltype(x4::remove_first_context<ID_To_Remove>(ctx.next));
 
-            // If the recursive replacement resulted in a monostate context,
-            // prevent appending it; return the context without `next`.
-            if constexpr (std::same_as<NewNext, detail::monostate_context>) {
-                return context<ID, T>{ctx.val};
+            if constexpr (std::same_as<std::remove_cvref_t<NewNext>, std::remove_cvref_t<Next>>) {
+                // Avoid creating copy on exact same type
+                return ctx;
 
-            } else if constexpr (std::is_reference_v<NewNext>) {
-                // Assert `decltype(auto)` is working as intended; i.e., no dangling reference
-                static_assert(std::is_lvalue_reference_v<NewNext>);
+            } else {
+                // If the recursive replacement resulted in a monostate context,
+                // prevent appending it; return the context without `next`.
+                if constexpr (std::same_as<std::remove_cvref_t<NewNext>, detail::monostate_context>) {
+                    return context<ID, T>{ctx.val};
 
-                if constexpr (std::same_as<Next, std::remove_cvref_t<NewNext>>) {
-                    // Avoid creating copy on exact same type
-                    return ctx;
-                } else {
-                    return context<ID, T, std::remove_cvref_t<NewNext>>{
+                } else if constexpr (std::is_reference_v<NewNext>) {
+                    // Assert `decltype(auto)` is working as intended; i.e., no dangling reference
+                    static_assert(std::is_lvalue_reference_v<NewNext>);
+
+                    return context<ID, T, NewNext>{
+                        ctx.val, x4::remove_first_context<ID_To_Remove>(ctx.next)
+                    };
+
+                } else { // prvalue context
+                    return context<ID, T, NewNext>{
                         ctx.val, x4::remove_first_context<ID_To_Remove>(ctx.next)
                     };
                 }
-
-            } else { // prvalue context
-                return context<ID, T, owning_context<NewNext>>{
-                    ctx.val, x4::remove_first_context<ID_To_Remove>(ctx.next)
-                };
             }
         }
     }
@@ -418,6 +461,77 @@ remove_first_context(context<ID, T, Next> const& ctx) noexcept
 
 template<class ID_To_Remove, class ID, class T, class Next>
 void remove_first_context(context<ID, T, Next> const&&) = delete; // dangling
+
+// Replaces the contained reference of the leftmost context
+// having the id `ID_To_Replace`. If no such context exists,
+// append a new one.
+//
+// This helper makes it possible to dynamically update the
+// reference bound to the (runtime) context, while avoiding
+// infinite instantiation in recursive grammars.
+//
+// The most notable example of a parser that requires this
+// operation is `x4::locals`. Without this helper, it would
+// inevitably trigger infinite instantiation when binding
+// a local variable instance to the context.
+template<class ID_To_Replace, class ID, class T, class Next, class NewVal>
+[[nodiscard]] constexpr decltype(auto)
+replace_first_context(
+    context<ID, T, Next> const& ctx,
+    NewVal& new_val BOOST_SPIRIT_LIFETIMEBOUND
+) noexcept
+{
+    static_assert(!is_ttp_specialization_of_v<std::remove_const_t<NewVal>, context>, "context's value type cannot be context");
+    static_assert(!std::same_as<ID_To_Replace, detail::monostate_context_tag>);
+
+    if constexpr (
+        detail::UniqueContextID<ID_To_Replace> &&
+        !detail::AllowUnusedContextID<ID_To_Replace> &&
+        std::same_as<std::remove_const_t<NewVal>, unused_type>
+    ) {
+        (void)new_val; // == unused
+        return x4::remove_first_context<ID_To_Replace>(ctx);
+
+    } else {
+        if constexpr (std::same_as<ID, ID_To_Replace>) { // Match
+            if constexpr (std::same_as<Next, unused_type>) {
+                // Existing context found; replace it and end the search.
+                return context<ID, NewVal, Next>{new_val};
+
+            } else {
+                // Existing context found; replace it and end the search.
+                //
+                // This implementation does not replace succeeding (duplicate) entries,
+                // because it is `replace_*first*_context`.
+                return context<ID, NewVal, Next>{new_val, ctx.next};
+            }
+
+        } else { // No match
+            if constexpr (std::same_as<ID, detail::monostate_context_tag>) {
+                // No match at all. Create a brand-new context.
+                return context<ID_To_Replace, NewVal>{new_val};
+
+            } else if constexpr (std::same_as<Next, unused_type>) {
+                // No match at all. Append a new one and return.
+                // Since we're doing the search from left to right,
+                // this branch means there was no existing context
+                // for `ID_To_Replace`.
+                return context<ID, T, context<ID_To_Replace, NewVal>>{
+                    ctx.val, context<ID_To_Replace, NewVal>{new_val}
+                };
+
+            } else {
+                // No match. Continue the replacement recursively.
+                return context<ID, T, decltype(x4::replace_first_context<ID_To_Replace>(ctx.next, new_val))>{
+                    ctx.val, x4::replace_first_context<ID_To_Replace>(ctx.next, new_val)
+                };
+            }
+        }
+    }
+}
+
+template<class ID_To_Replace, class ID, class T, class Next, class NewVal>
+void replace_first_context(context<ID, T, Next> const&, NewVal const&&) = delete; // dangling
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/core/expectation.hpp
+++ b/include/boost/spirit/x4/core/expectation.hpp
@@ -24,10 +24,16 @@
 
 namespace boost::spirit::x4 {
 
-struct expectation_failure_tag
+namespace contexts {
+
+struct expectation_failure
 {
     static constexpr bool is_unique = true;
 };
+
+} // contexts
+
+using expectation_failure_tag [[deprecated("Use `x4::contexts::expectation_failure`")]] = contexts::expectation_failure;
 
 template<std::forward_iterator It>
 struct expectation_failure
@@ -98,7 +104,7 @@ constexpr void swap(expectation_failure<It>& a, expectation_failure<It>& b)
 }
 
 template<class Context>
-using expectation_failure_t = get_context_plain_t<expectation_failure_tag, Context>;
+using expectation_failure_t = get_context_plain_t<contexts::expectation_failure, Context>;
 
 template<class Context>
 [[nodiscard]]
@@ -107,11 +113,11 @@ constexpr bool has_expectation_failure(Context const& ctx) noexcept
     using T = expectation_failure_t<Context>;
     static_assert(
         !std::same_as<unused_type, T>,
-        "Context type was not specified for x4::expectation_failure_tag. "
-        "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
+        "Context type was not specified for `x4::contexts::expectation_failure`. "
+        "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
     );
-    return x4::get<expectation_failure_tag>(ctx).has_value();
+    return x4::get<contexts::expectation_failure>(ctx).has_value();
 }
 
 //
@@ -124,16 +130,16 @@ constexpr void set_expectation_failure(
     Subject const& subject,
     Context const& ctx
 )
-    noexcept(noexcept(x4::get<expectation_failure_tag>(ctx).emplace(std::move(where), x4::what(subject))))
+    noexcept(noexcept(x4::get<contexts::expectation_failure>(ctx).emplace(std::move(where), x4::what(subject))))
 {
     using T = expectation_failure_t<Context>;
     static_assert(
         !std::same_as<unused_type, T>,
-        "Context type was not specified for x4::expectation_failure_tag. "
-        "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
+        "Context type was not specified for `x4::contexts::expectation_failure`. "
+        "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
     );
-    x4::get<expectation_failure_tag>(ctx).emplace(std::move(where), x4::what(subject));
+    x4::get<contexts::expectation_failure>(ctx).emplace(std::move(where), x4::what(subject));
 }
 
 template<class Context>
@@ -143,12 +149,12 @@ constexpr decltype(auto) get_expectation_failure(Context const& ctx) noexcept
     using T = expectation_failure_t<Context>;
     static_assert(
         !std::same_as<T, unused_type>,
-        "Context type was not specified for x4::expectation_failure_tag. "
-        "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
+        "Context type was not specified for `x4::contexts::expectation_failure`. "
+        "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
     );
 
-    return x4::get<expectation_failure_tag>(ctx);
+    return x4::get<contexts::expectation_failure>(ctx);
 }
 
 template<class Context>
@@ -157,11 +163,11 @@ constexpr void clear_expectation_failure(Context const& ctx) noexcept
     using T = expectation_failure_t<Context>;
     static_assert(
         !std::same_as<T, unused_type>,
-        "Context type was not specified for x4::expectation_failure_tag. "
-        "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
+        "Context type was not specified for `x4::contexts::expectation_failure`. "
+        "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
     );
-    x4::get<expectation_failure_tag>(ctx).clear();
+    x4::get<contexts::expectation_failure>(ctx).clear();
 }
 
 } // boost::spirit::x4

--- a/include/boost/spirit/x4/debug/annotate_on_success.hpp
+++ b/include/boost/spirit/x4/debug/annotate_on_success.hpp
@@ -11,13 +11,19 @@
 
 #include <boost/spirit/x4/core/context.hpp>
 #include <boost/spirit/x4/core/unused.hpp>
+#include <boost/spirit/x4/core/attribute.hpp>
 
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 
 namespace boost::spirit::x4 {
 
-struct error_handler_tag;
+namespace contexts {
+
+struct error_handler;
+
+} // contexts
 
 //  The on_success handler tags the AST with the iterator position
 //  for error handling.
@@ -31,16 +37,16 @@ struct error_handler_tag;
 struct annotate_on_success
 {
     // Catch-all default overload
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class T, class Context>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
     constexpr void
-    on_success(It const& first, Se const& last, T& ast, Context const& ctx)
+    on_success(It const& first, Se const& last, Context const& ctx, Attr& ast)
     {
-        auto&& error_handler_ref = x4::get<error_handler_tag>(ctx);
+        auto&& error_handler_ref = x4::get<contexts::error_handler>(ctx);
 
         static_assert(
-            !std::is_same_v<std::remove_cvref_t<decltype(error_handler_ref)>, unused_type>,
+            !std::same_as<std::remove_cvref_t<decltype(error_handler_ref)>, unused_type>,
             "This rule is derived from `x4::annotate_on_success`, but no reference was bound to "
-            "`x4::error_handler_tag`. You must provide a viable error handler via `x4::with`."
+            "`x4::contexts::error_handler`. You must provide a viable error handler via `x4::with`."
         );
 
         // unwrap `reference_wrapper` if necessary

--- a/include/boost/spirit/x4/debug/detail/parse_callback.hpp
+++ b/include/boost/spirit/x4/debug/detail/parse_callback.hpp
@@ -84,7 +84,7 @@ struct has_on_error<ID, It, Se, Context> : std::false_type
     );
 };
 
-template<class ID, class It, class Se, typename Attr, class Context>
+template<class ID, class It, class Se, class Context, class Attr>
 concept HasImmutableOnSuccessOverload =
     std::forward_iterator<It> &&
     std::sentinel_for<Se, It> &&
@@ -93,12 +93,12 @@ concept HasImmutableOnSuccessOverload =
         id.on_success(
             std::declval<It const&>(),
             std::declval<Se const&>(),
-            std::declval<Attr&>(),
-            std::declval<Context const&>()
+            std::declval<Context const&>(),
+            std::declval<Attr&>()
         );
     };
 
-template<class ID, class It, class Se, typename Attr, class Context>
+template<class ID, class It, class Se, class Context, class Attr>
 concept HasMutableOnSuccessOverload =
     std::forward_iterator<It> &&
     std::sentinel_for<Se, It> &&
@@ -107,17 +107,17 @@ concept HasMutableOnSuccessOverload =
         id.on_success(
             std::declval<It&>(),
             std::declval<Se&>(),
-            std::declval<Attr&>(),
-            std::declval<Context const&>()
+            std::declval<Context const&>(),
+            std::declval<Attr&>()
         );
     };
 
-template<class ID, std::forward_iterator It, std::sentinel_for<It> Se, X4Attribute Attr, class Context>
+template<class ID, std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
 struct has_on_success : std::false_type {};
 
-template<class ID, std::forward_iterator It, std::sentinel_for<It> Se, X4Attribute Attr, class Context>
-    requires HasImmutableOnSuccessOverload<ID, It, Se, Attr, Context>
-struct has_on_success<ID, It, Se, Attr, Context> : std::true_type
+template<class ID, std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
+    requires HasImmutableOnSuccessOverload<ID, It, Se, Context, Attr>
+struct has_on_success<ID, It, Se, Context, Attr> : std::true_type
 {
     // We intentionally make this hard error to prevent error-prone definition
     static_assert(
@@ -125,19 +125,19 @@ struct has_on_success<ID, It, Se, Attr, Context> : std::true_type
             decltype(std::declval<ID&>().on_success(
                 std::declval<It const&>(),
                 std::declval<Se const&>(),
-                std::declval<Attr&>(),
-                std::declval<Context const&>()
+                std::declval<Context const&>(),
+                std::declval<Attr&>()
             ))
         >,
         "The return type of `on_success` should be `void`."
     );
 };
 
-template<class ID, std::forward_iterator It, std::sentinel_for<It> Se, X4Attribute Attr, class Context>
+template<class ID, std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
     requires
-        (!HasImmutableOnSuccessOverload<ID, It, Se, Attr, Context>) &&
-        HasMutableOnSuccessOverload<ID, It, Se, Attr, Context>
-struct has_on_success<ID, It, Se, Attr, Context> : std::false_type
+        (!HasImmutableOnSuccessOverload<ID, It, Se, Context, Attr>) &&
+        HasMutableOnSuccessOverload<ID, It, Se, Context, Attr>
+struct has_on_success<ID, It, Se, Context, Attr> : std::false_type
 {
     // For details, see the comments on `has_on_error`.
     static_assert(

--- a/include/boost/spirit/x4/debug/error_reporting.hpp
+++ b/include/boost/spirit/x4/debug/error_reporting.hpp
@@ -18,7 +18,17 @@
 namespace boost::spirit::x4 {
 
 // Tag used to get our error handler from the context
-struct error_handler_tag;
+
+namespace contexts {
+
+struct error_handler
+{
+    static constexpr bool is_unique = true;
+};
+
+} // contexts
+
+using error_handler_tag [[deprecated("Use `x4::contexts::error_handler`")]] = contexts::error_handler;
 
 template<std::forward_iterator It>
 class error_handler

--- a/include/boost/spirit/x4/directive/lexeme.hpp
+++ b/include/boost/spirit/x4/directive/lexeme.hpp
@@ -37,7 +37,7 @@ struct lexeme_directive : unary_parser<Subject, lexeme_directive<Subject>>
 
     template<class Context>
     using pre_skip_context_t = std::remove_cvref_t<decltype(
-        x4::make_context<skipper_tag>(std::declval<unused_skipper_t<Context>&>(), std::declval<Context const&>())
+        x4::make_context<contexts::skipper>(std::declval<unused_skipper_t<Context>&>(), std::declval<Context const&>())
     )>;
 
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
@@ -51,12 +51,12 @@ struct lexeme_directive : unary_parser<Subject, lexeme_directive<Subject>>
     {
         x4::skip_over(first, last, ctx);
 
-        auto const& skipper = x4::get<skipper_tag>(ctx);
+        auto const& skipper = x4::get<contexts::skipper>(ctx);
         unused_skipper_t<Context> unused_skipper(skipper);
 
         return this->subject.parse(
             first, last,
-            x4::make_context<skipper_tag>(unused_skipper, ctx),
+            x4::make_context<contexts::skipper>(unused_skipper, ctx),
             attr
         );
     }

--- a/include/boost/spirit/x4/directive/no_skip.hpp
+++ b/include/boost/spirit/x4/directive/no_skip.hpp
@@ -42,9 +42,9 @@ struct no_skip_directive : unary_parser<Subject, no_skip_directive<Subject>>
 private:
     template<class Context>
     using unused_skipper_context_t = x4::context<
-        skipper_tag,
+        contexts::skipper,
         unused_skipper<
-            std::remove_reference_t<decltype(x4::get<skipper_tag>(std::declval<Context const&>()))>
+            std::remove_reference_t<decltype(x4::get<contexts::skipper>(std::declval<Context const&>()))>
         >,
         Context
     >;
@@ -60,14 +60,14 @@ public:
             Attr
         >)
     {
-        auto const& skipper = x4::get<skipper_tag>(ctx);
+        auto const& skipper = x4::get<contexts::skipper>(ctx);
 
         unused_skipper<std::remove_reference_t<decltype(skipper)>>
         unused_skipper(skipper);
 
         return this->subject.parse(
             first, last,
-            x4::make_context<skipper_tag>(unused_skipper, ctx),
+            x4::make_context<contexts::skipper>(unused_skipper, ctx),
             attr
         );
     }

--- a/include/boost/spirit/x4/directive/skip.hpp
+++ b/include/boost/spirit/x4/directive/skip.hpp
@@ -51,9 +51,9 @@ struct reskip_directive : unary_parser<Subject, reskip_directive<Subject>>
 private:
     template<class Context>
     using context_t = context<
-        skipper_tag,
+        contexts::skipper,
         std::remove_cvref_t<decltype(detail::get_unused_skipper(
-            std::declval<get_context_plain_t<skipper_tag, Context> const&>()
+            std::declval<get_context_plain_t<contexts::skipper, Context> const&>()
         ))>,
         Context
     >;
@@ -67,8 +67,8 @@ public:
     {
         // This logic is heavily related to the instantiation chain;
         // see `x4::skip_over` for details.
-        auto const& skipper = detail::get_unused_skipper(x4::get<skipper_tag>(ctx));
-        return this->subject.parse(first, last, x4::make_context<skipper_tag>(skipper, ctx), attr);
+        auto const& skipper = detail::get_unused_skipper(x4::get<contexts::skipper>(ctx));
+        return this->subject.parse(first, last, x4::make_context<contexts::skipper>(skipper, ctx), attr);
     }
 };
 
@@ -90,18 +90,18 @@ struct skip_directive : unary_parser<Subject, skip_directive<Subject, Skipper>>
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
-        noexcept(is_nothrow_parsable_v<Subject, It, Se, x4::context<skipper_tag, Skipper, Context>, Attr>)
+        noexcept(is_nothrow_parsable_v<Subject, It, Se, context<contexts::skipper, Skipper, Context>, Attr>)
     {
         static_assert(
             !std::same_as<expectation_failure_t<Context>, unused_type>,
-            "Context type was not specified for x4::expectation_failure_tag. "
-            "You probably forgot: `x4::with<x4::expectation_failure_tag>(failure)[p]`. "
+            "Context type was not specified for `x4::contexts::expectation_failure`. "
+            "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
             "Note that you must also bind the context to your skipper."
         );
 
         // This logic is heavily related to the instantiation chain;
         // see `x4::skip_over` for details.
-        return this->subject.parse(first, last, x4::make_context<skipper_tag>(skipper_, ctx), attr);
+        return this->subject.parse(first, last, x4::make_context<contexts::skipper>(skipper_, ctx), attr);
     }
 
 private:

--- a/test/x4/context.cpp
+++ b/test/x4/context.cpp
@@ -11,81 +11,167 @@
 
 #include <concepts>
 #include <memory>
+#include <type_traits>
 #include <utility>
 
 int main()
 {
     using x4::context;
-    using x4::owning_context;
+    struct existent_tag;
+    struct non_existent_tag;
 
-    struct tag;
-    struct nonexistent_tag;
+    {
+        struct IntRef { int& ref; };  // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+        static_assert(sizeof(context<struct i_, int>) == sizeof(IntRef));
+        static_assert(sizeof(context<struct i_, int, context<struct d_, double>>) == sizeof(IntRef) * 2);
+        static_assert(sizeof(context<struct i_, int, context<struct d_, double> const&>) == sizeof(IntRef) * 2);
+    }
 
     {
         int i = 42;
-        auto ctx = x4::make_context<tag>(std::as_const(i));
-        BOOST_TEST(x4::get<tag>(ctx) == 42);
-        static_assert(std::same_as<decltype(x4::get<tag>(ctx)), int const&>);
-        static_assert(std::same_as<decltype(x4::get<tag>(std::as_const(ctx))), int const&>);
+        auto ctx = x4::make_context<existent_tag>(i);
+
+        using Context = decltype(ctx);
+        static_assert(std::same_as<Context, context<existent_tag, int>>);
+        static_assert(std::move_constructible<Context>);
+        static_assert(std::copy_constructible<Context>);
+        static_assert(!std::assignable_from<Context&, Context>);
+
+        BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+
+        {
+            auto&& removed_ctx = x4::remove_first_context<existent_tag>(ctx);
+            static_assert(std::same_as<decltype(removed_ctx), x4::detail::monostate_context&&>);
+
+            // monostate tests
+            {
+                auto&& mono_removed_ctx = x4::remove_first_context<non_existent_tag>(removed_ctx);
+                static_assert(std::same_as<decltype(mono_removed_ctx), x4::detail::monostate_context const&>);
+                (void)mono_removed_ctx;
+            }
+            {
+                double d = 3.14;
+                auto&& mono_replaced_ctx = x4::replace_first_context<non_existent_tag>(removed_ctx, d);
+                static_assert(std::same_as<decltype(mono_replaced_ctx), context<non_existent_tag, double>&&>);
+                BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+                BOOST_TEST(x4::get<non_existent_tag>(mono_replaced_ctx) == 3.14);
+            }
+        }
+        {
+            auto&& removed_ctx = x4::remove_first_context<non_existent_tag>(ctx);
+            static_assert(std::same_as<decltype(removed_ctx), context<existent_tag, int> const&>);
+            BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+            BOOST_TEST(x4::get<existent_tag>(removed_ctx) == 42);
+        }
+        {
+            double d = 3.14;
+            auto&& replaced_ctx = x4::replace_first_context<existent_tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, double>&&>);
+            BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 3.14);
+        }
+        {
+            double d = 3.14;
+            auto&& replaced_ctx = x4::replace_first_context<non_existent_tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, int, context<non_existent_tag, double>>&&>);
+            BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 42);
+            BOOST_TEST(x4::get<non_existent_tag>(replaced_ctx) == 3.14);
+
+            i = 43;
+            BOOST_TEST(x4::get<existent_tag>(ctx) == 43);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 43);
+            i = 42;
+        }
+
+        {
+            auto ctx_ctx = x4::make_context<non_existent_tag>(i, ctx);
+            using ContextContext = decltype(ctx_ctx);
+            static_assert(std::same_as<ContextContext, context<non_existent_tag, int, context<existent_tag, int> const&>>);
+            static_assert(std::move_constructible<ContextContext>);
+            static_assert(std::copy_constructible<ContextContext>);
+            static_assert(!std::assignable_from<ContextContext&, ContextContext>);
+
+            BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+            BOOST_TEST(x4::get<existent_tag>(ctx_ctx) == 42);
+            i = 43;
+            BOOST_TEST(x4::get<existent_tag>(ctx) == 43);
+            BOOST_TEST(x4::get<existent_tag>(ctx_ctx) == 43);
+            i = 42;
+
+            static_assert(std::move_constructible<Context>);
+            static_assert(std::copy_constructible<Context>);
+            static_assert(!std::assignable_from<Context&, Context>);
+        }
+    }
+
+    // ---------------------------------------
+
+    {
+        int i = 42;
+        auto ctx = x4::make_context<existent_tag>(std::as_const(i));
+        BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+        static_assert(std::same_as<decltype(x4::get<existent_tag>(ctx)), int const&>);
+        static_assert(std::same_as<decltype(x4::get<existent_tag>(std::as_const(ctx))), int const&>);
     }
 
     // Start with plain `context<tag, int>`
     {
         int i = 42;
-        auto ctx = x4::make_context<tag>(i);
-        static_assert(std::same_as<decltype(ctx), context<tag, int>>);
-        BOOST_TEST(x4::get<tag>(ctx) == 42);
-        static_assert(std::same_as<decltype(x4::get<tag>(ctx)), int&>);
-        static_assert(std::same_as<decltype(x4::get<tag>(std::as_const(ctx))), int&>);
+        auto ctx = x4::make_context<existent_tag>(i);
+        static_assert(std::same_as<decltype(ctx), context<existent_tag, int>>);
+        BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+        static_assert(std::same_as<decltype(x4::get<existent_tag>(ctx)), int&>);
+        static_assert(std::same_as<decltype(x4::get<existent_tag>(std::as_const(ctx))), int&>);
         BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
 
         {
             int j = 999;
-            auto&& replaced_ctx = x4::replace_first_context<tag>(ctx, j);
-            static_assert(std::same_as<decltype(replaced_ctx), context<tag, int>&&>);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 999);
+            auto&& replaced_ctx = x4::replace_first_context<existent_tag>(ctx, j);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, int>&&>);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 999);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
             BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(j));
 
             {
-                auto&& removed_ctx = x4::remove_first_context<nonexistent_tag>(replaced_ctx);
-                static_assert(std::same_as<decltype(removed_ctx), context<tag, int> const&>);
+                auto&& removed_ctx = x4::remove_first_context<non_existent_tag>(replaced_ctx);
+                static_assert(std::same_as<decltype(removed_ctx), context<existent_tag, int> const&>);
                 BOOST_TEST(std::addressof(removed_ctx) == std::addressof(replaced_ctx));
             }
             {
-                auto&& removed_ctx = x4::remove_first_context<tag>(replaced_ctx);
+                auto&& removed_ctx = x4::remove_first_context<existent_tag>(replaced_ctx);
                 static_assert(std::same_as<decltype(removed_ctx), x4::detail::monostate_context&&>);
 
                 {
-                    [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<tag>(removed_ctx);
+                    [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<existent_tag>(removed_ctx);
                     static_assert(std::same_as<decltype(removed_removed_ctx), x4::detail::monostate_context const&>);
                 }
                 {
-                    [[maybe_unused]] auto&& new_ctx = x4::make_context<tag>(i, removed_ctx);
-                    static_assert(std::same_as<decltype(new_ctx), context<tag, int>&&>);
+                    [[maybe_unused]] auto&& new_ctx = x4::make_context<existent_tag>(i, removed_ctx);
+                    static_assert(std::same_as<decltype(new_ctx), context<existent_tag, int>&&>);
                 }
                 {
-                    auto&& new_ctx = x4::replace_first_context<tag>(removed_ctx, i);
-                    static_assert(std::same_as<decltype(new_ctx), context<tag, int>&&>);
+                    auto&& new_ctx = x4::replace_first_context<existent_tag>(removed_ctx, i);
+                    static_assert(std::same_as<decltype(new_ctx), context<existent_tag, int>&&>);
                     BOOST_TEST(std::addressof(new_ctx.val) == std::addressof(i));
                 }
             }
         }
         {
             double d = 3.14;
-            auto replaced_ctx = x4::replace_first_context<tag>(ctx, d);
-            static_assert(std::same_as<decltype(replaced_ctx), context<tag, double>>);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 3.14);
+            auto replaced_ctx = x4::replace_first_context<existent_tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, double>>);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 3.14);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
             BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(d));
         }
         {
             double d = 3.14;
-            auto replaced_ctx = x4::replace_first_context<nonexistent_tag>(ctx, d);
-            static_assert(std::same_as<decltype(replaced_ctx), context<tag, int, owning_context<context<nonexistent_tag, double>>>>);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 42);
+            auto replaced_ctx = x4::replace_first_context<non_existent_tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, int, context<non_existent_tag, double>>>);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 42);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
-            BOOST_TEST(std::addressof(x4::get<nonexistent_tag>(replaced_ctx)) == std::addressof(d));
+            BOOST_TEST(std::addressof(x4::get<non_existent_tag>(replaced_ctx)) == std::addressof(d));
         }
     }
 
@@ -100,46 +186,46 @@ int main()
         static_assert(std::same_as<decltype(dummy_ctx), dummy_ctx_t const>);
 
         int i = 42;
-        auto ctx = x4::make_context<tag>(i, dummy_ctx);
-        static_assert(std::same_as<decltype(ctx), context<tag, int, dummy_ctx_t>>);
-        BOOST_TEST(x4::get<tag>(ctx) == 42);
-        static_assert(std::same_as<decltype(x4::get<tag>(ctx)), int&>);
-        static_assert(std::same_as<decltype(x4::get<tag>(std::as_const(ctx))), int&>);
+        auto ctx = x4::make_context<existent_tag>(i, dummy_ctx);
+        static_assert(std::same_as<decltype(ctx), context<existent_tag, int, dummy_ctx_t const&>>);
+        BOOST_TEST(x4::get<existent_tag>(ctx) == 42);
+        static_assert(std::same_as<decltype(x4::get<existent_tag>(ctx)), int&>);
+        static_assert(std::same_as<decltype(x4::get<existent_tag>(std::as_const(ctx))), int&>);
         BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
 
         {
             int j = 999;
-            auto&& replaced_ctx = x4::replace_first_context<tag>(ctx, j);
-            static_assert(std::same_as<decltype(replaced_ctx), context<tag, int, dummy_ctx_t>&&>);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 999);
+            auto&& replaced_ctx = x4::replace_first_context<existent_tag>(ctx, j);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, int, dummy_ctx_t const&>&&>);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 999);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
             BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(j));
 
             {
-                auto&& removed_ctx = x4::remove_first_context<nonexistent_tag>(replaced_ctx);
-                static_assert(std::same_as<decltype(removed_ctx), context<tag, int, dummy_ctx_t> const&>);
+                auto&& removed_ctx = x4::remove_first_context<non_existent_tag>(replaced_ctx);
+                static_assert(std::same_as<decltype(removed_ctx), context<existent_tag, int, dummy_ctx_t const&> const&>);
                 BOOST_TEST(std::addressof(removed_ctx) == std::addressof(replaced_ctx));
 
                 {
-                    [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<tag>(removed_ctx);
+                    [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<existent_tag>(removed_ctx);
                     static_assert(std::same_as<decltype(removed_removed_ctx), dummy_ctx_t const&>);
                 }
                 {
-                    [[maybe_unused]] auto&& new_ctx = x4::make_context<nonexistent_tag>(i, removed_ctx);
-                    static_assert(std::same_as<decltype(new_ctx), context<nonexistent_tag, int, context<tag, int, dummy_ctx_t>>&&>);
+                    [[maybe_unused]] auto new_ctx = x4::make_context<non_existent_tag>(i, removed_ctx);
+                    static_assert(std::same_as<decltype(new_ctx), context<non_existent_tag, int, context<existent_tag, int, dummy_ctx_t const&> const&>>);
                 }
                 {
-                    auto&& new_ctx = x4::replace_first_context<tag>(removed_ctx, i);
-                    static_assert(std::same_as<decltype(new_ctx), context<tag, int, dummy_ctx_t>&&>);
+                    auto&& new_ctx = x4::replace_first_context<existent_tag>(removed_ctx, i);
+                    static_assert(std::same_as<decltype(new_ctx), context<existent_tag, int, dummy_ctx_t const&>&&>);
                     BOOST_TEST(std::addressof(new_ctx.val) == std::addressof(i));
                 }
             }
         }
         {
             double d = 3.14;
-            auto&& replaced_ctx = x4::replace_first_context<tag>(ctx, d);
-            static_assert(std::same_as<decltype(replaced_ctx), context<tag, double, dummy_ctx_t>&&>);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 3.14);
+            auto&& replaced_ctx = x4::replace_first_context<existent_tag>(ctx, d);
+            static_assert(std::same_as<decltype(replaced_ctx), context<existent_tag, double, dummy_ctx_t const&>&&>);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 3.14);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
             BOOST_TEST(std::addressof(replaced_ctx.val) == std::addressof(d));
         }
@@ -149,34 +235,34 @@ int main()
             static_assert(std::same_as<
                 decltype(replaced_ctx),
                 context<
-                    tag, int,
-                    owning_context<context<
+                    existent_tag, int,
+                    context<
                         dummy_tag, double
-                    >>
+                    >
                 >&&
             >);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 42);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 42);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
             BOOST_TEST(std::addressof(x4::get<dummy_tag>(replaced_ctx)) == std::addressof(d));
         }
         {
             double d = 3.14;
-            auto&& replaced_ctx = x4::replace_first_context<nonexistent_tag>(ctx, d);
+            auto&& replaced_ctx = x4::replace_first_context<non_existent_tag>(ctx, d);
             static_assert(std::same_as<
                 decltype(replaced_ctx),
                 context<
-                    tag, int,
-                    owning_context<context<
+                    existent_tag, int,
+                    context<
                         dummy_tag, dummy_t const,
-                        owning_context<context<
-                            nonexistent_tag, double
-                        >>
-                    >>
+                        context<
+                            non_existent_tag, double
+                        >
+                    >
                 >&&
             >);
-            BOOST_TEST(x4::get<tag>(replaced_ctx) == 42);
+            BOOST_TEST(x4::get<existent_tag>(replaced_ctx) == 42);
             BOOST_TEST(std::addressof(ctx.val) == std::addressof(i));
-            BOOST_TEST(std::addressof(x4::get<nonexistent_tag>(replaced_ctx)) == std::addressof(d));
+            BOOST_TEST(std::addressof(x4::get<non_existent_tag>(replaced_ctx)) == std::addressof(d));
         }
     }
 

--- a/test/x4/debug.cpp
+++ b/test/x4/debug.cpp
@@ -132,7 +132,7 @@ int main()
         auto r_def = '(' > int_ > ',' > int_ > ')';
         my_error_handler error_handler;
 
-        auto parser = x4::with<x4::error_handler_tag>(error_handler)[r_def];
+        auto parser = x4::with<x4::contexts::error_handler>(error_handler)[r_def];
 
         BOOST_TEST( parse("(123,456)", parser));
         BOOST_TEST(!parse("(abc,def)", parser));

--- a/test/x4/expect.cpp
+++ b/test/x4/expect.cpp
@@ -177,8 +177,6 @@ int main()
     using x4::shared_symbols;
     using x4::confix;
     using x4::with;
-    using x4::expectation_failure;
-    using x4::expectation_failure_tag;
 
     using boost::fusion::vector;
     using boost::fusion::at_c;

--- a/test/x4/rule4.cpp
+++ b/test/x4/rule4.cpp
@@ -23,16 +23,14 @@
 #include <cstring>
 #include <iostream>
 
-namespace x4 = boost::spirit::x4;
-
 namespace {
 
 int got_it = 0;
 
 struct my_rule_class
 {
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Exception, class Context>
-    void on_error(It const&, Se const& last, Exception const& x, Context const&)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, class Failure>
+    static void on_error(It const&, Se const& last, Context const&, Failure const& x)
     {
         std::cout
             << "Error! Expecting: "
@@ -43,8 +41,8 @@ struct my_rule_class
             << std::endl;
     }
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Attr, class Context>
-    void on_success(It const&, Se const&, Attr&, Context const&)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, x4::X4Attribute Attr>
+    static void on_success(It const&, Se const&, Context const&, Attr&)
     {
         ++got_it;
     }
@@ -52,17 +50,15 @@ struct my_rule_class
 
 struct on_success_gets_preskipped_iterator
 {
-    static bool ok;
+    inline static bool ok = false;
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Attr, class Context>
-    void on_success(It before, Se const& after, Attr&, Context const&)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, x4::X4Attribute Attr>
+    static void on_success(It before, Se const& after, Context const&, Attr&)
     {
         bool const before_was_b = 'b' == *before;
         ok = before_was_b && (++before == after);
     }
 };
-
-bool on_success_gets_preskipped_iterator::ok = false;
 
 } // anonymous
 

--- a/test/x4/rule_separate_tu.cpp
+++ b/test/x4/rule_separate_tu.cpp
@@ -68,23 +68,21 @@ int main()
     }
     {
         using Context = x4::context<
-            x4::expectation_failure_tag,
+            x4::contexts::expectation_failure,
             x4::expectation_failure<std::string_view::const_iterator>,
-            x4::owning_context<
-                x4::context<
-                    x4::rule_val_context_tag,
-                    int
-                >
+            x4::context<
+                x4::contexts::rule_val,
+                int
             >
         >;
         using RuleAgnosticContext = x4::context<
-            x4::expectation_failure_tag,
+            x4::contexts::expectation_failure,
             x4::expectation_failure<std::string_view::const_iterator>
         >;
 
         static_assert(std::same_as<
             std::remove_cvref_t<decltype(
-                x4::remove_first_context<x4::rule_val_context_tag>(std::declval<Context const&>())
+                x4::remove_first_context<x4::contexts::rule_val>(std::declval<Context const&>())
             )>,
             RuleAgnosticContext
         >);

--- a/test/x4/test.hpp
+++ b/test/x4/test.hpp
@@ -23,7 +23,8 @@
 #include <utility>
 #include <print>
 
-namespace x4 = boost::spirit::x4;
+namespace spirit = boost::spirit;
+namespace x4 = spirit::x4;
 
 using x4::unused_type;
 using x4::unused;

--- a/test/x4/with.cpp
+++ b/test/x4/with.cpp
@@ -26,14 +26,14 @@ struct my_tag;
 
 struct my_rule_class
 {
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Exception, class Context>
-    void on_error(It const&, Se const&, Exception const&, Context const& ctx)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Failure, class Context>
+    void on_error(It const&, Se const&, Context const& ctx, Failure const&)
     {
         ++x4::get<my_tag>(ctx);
     }
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Attr, class Context>
-    void on_success(It const&, Se const&, Attr&, Context const& ctx)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, x4::X4Attribute Attr>
+    void on_success(It const&, Se const&, Context const& ctx, Attr&)
     {
         ++x4::get<my_tag>(ctx);
     }


### PR DESCRIPTION
Part of #1. Improves the context-related helpers introduced in #37 (#11). 

This PR makes `x4::context` capable of holding a plain type (`Next`), while still maintaining the ability to hold const lvalue reference (`Next const&`) when the argument given to `x4::make_context` is strictly an lvalue.

This means we can hold the member variable `ctx.next` by plain type in a chained context creation (e.g. `x4::make_context(a, x4::make_context(b, ctx))`), without the need to create a local context variable just for _inventing_ lvalue reference. It is a huge optimization in assembly level, as the new implementation removes one layer of pointer indirection.

As a consequence, this change would make the context type much simpler for many parser invocations, and also reduces call stack for the `rule` parser.

Additionally, I eliminated all existing context  that materialized `unused_type` as the held value (note: this applies to both `T` and `Next`). It is a waste of space to hold a `unused_type const&`, as we can return `x4::unused` in `x4::get` even if the context does not hold such ID.

#### Key changes
- `x4/core/context.hpp`