### PR TITLE
More strict check for incompatible char types

### DIFF
--- a/include/boost/spirit/x4/char/char_parser.hpp
+++ b/include/boost/spirit/x4/char/char_parser.hpp
@@ -13,21 +13,71 @@
 #include <boost/spirit/x4/core/skip_over.hpp>
 #include <boost/spirit/x4/core/move_to.hpp>
 
+#include <boost/spirit/x4/traits/string_traits.hpp>
+
+#include <concepts>
 #include <iterator>
+#include <utility>
 
 namespace boost::spirit::x4 {
 
-template<class Derived>
+template<class Encoding, class Derived>
 struct char_parser : parser<Derived>
 {
+    using encoding_type = Encoding;
+    using char_type = typename Encoding::char_type;
+    using classify_type = typename Encoding::classify_type;
+
+private:
+    template<class Context>
+    static constexpr bool has_static_test = requires(classify_type classify_ch, Context const& ctx) {
+        { Derived::test(classify_ch, ctx) } -> std::same_as<bool>;
+    };
+
+public:
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
-    [[nodiscard]] constexpr bool
-    parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
-        // TODO: noexcept
+        requires has_static_test<Context>
+    [[nodiscard]] static constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, Attr& attr)
+        noexcept(
+            noexcept(x4::skip_over(first, last, ctx)) &&
+            noexcept(first != last) &&
+            noexcept(Derived::test(static_cast<classify_type>(*first), ctx)) &&
+            noexcept(x4::move_to(std::iter_value_t<It>{*first}, attr)) &&
+            noexcept(++first)
+        )
     {
+        static_assert(std::same_as<std::iter_value_t<It>, char_type>, "Mixing incompatible char types is not allowed");
+        static_assert(!traits::CharLike<Attr> || std::same_as<Attr, char_type>, "Mixing incompatible char types is not allowed");
+
         x4::skip_over(first, last, ctx);
 
-        if (first != last && this->derived().test(*first, ctx)) {
+        if (first != last && Derived::test(static_cast<classify_type>(*first), ctx)) {
+            x4::move_to(std::iter_value_t<It>{*first}, attr);
+            ++first;
+            return true;
+        }
+        return false;
+    }
+
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
+        requires (!has_static_test<Context>)
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
+        noexcept(
+            noexcept(x4::skip_over(first, last, ctx)) &&
+            noexcept(first != last) &&
+            noexcept(this->derived().test(static_cast<classify_type>(*first), ctx)) &&
+            noexcept(x4::move_to(std::iter_value_t<It>{*first}, attr)) &&
+            noexcept(++first)
+        )
+    {
+        static_assert(std::same_as<std::iter_value_t<It>, char_type>, "Mixing incompatible char types is not allowed");
+        static_assert(!traits::CharLike<Attr> || std::same_as<Attr, char_type>, "Mixing incompatible char types is not allowed");
+
+        x4::skip_over(first, last, ctx);
+
+        if (first != last && this->derived().test(static_cast<classify_type>(*first), ctx)) {
             x4::move_to(std::iter_value_t<It>{*first}, attr);
             ++first;
             return true;

--- a/include/boost/spirit/x4/char/char_set.hpp
+++ b/include/boost/spirit/x4/char/char_set.hpp
@@ -22,11 +22,12 @@ namespace boost::spirit::x4 {
 
 // Parser for a character range
 template<class Encoding, X4Attribute Attr = typename Encoding::char_type>
-struct char_range : char_parser<char_range<Encoding, Attr>>
+struct char_range : char_parser<Encoding, char_range<Encoding, Attr>>
 {
     using char_type = typename Encoding::char_type;
-    using encoding = Encoding;
+    using encoding_type = Encoding;
     using attribute_type = Attr;
+
     static constexpr bool has_attribute = !std::is_same_v<unused_type, attribute_type>;
 
     constexpr char_range(char_type from_, char_type to_) noexcept
@@ -38,8 +39,10 @@ struct char_range : char_parser<char_range<Encoding, Attr>>
     [[nodiscard]] constexpr bool test(Char ch_, Context const& ctx) const noexcept
     {
         char_type ch = static_cast<char_type>(ch_);  // optimize for token based parsing
-        return x4::get_case_compare<encoding>(ctx)(ch, from) >= 0
-            && x4::get_case_compare<encoding>(ctx)(ch , to) <= 0;
+        static_assert(noexcept(x4::get_case_compare<encoding_type>(ctx)(ch, from)));
+
+        return x4::get_case_compare<encoding_type>(ctx)(ch, from) >= 0
+            && x4::get_case_compare<encoding_type>(ctx)(ch , to) <= 0;
     }
 
     char_type from, to;
@@ -47,10 +50,10 @@ struct char_range : char_parser<char_range<Encoding, Attr>>
 
 // Parser for a character set
 template<class Encoding, X4Attribute Attr = typename Encoding::char_type>
-struct char_set : char_parser<char_set<Encoding, Attr>>
+struct char_set : char_parser<Encoding, char_set<Encoding, Attr>>
 {
     using char_type = typename Encoding::char_type;
-    using encoding = Encoding;
+    using encoding_type = Encoding;
     using attribute_type = Attr;
 
     static constexpr bool has_attribute = !std::is_same_v<unused_type, attribute_type>;
@@ -94,7 +97,8 @@ struct char_set : char_parser<char_set<Encoding, Attr>>
     template<class Char, class Context>
     [[nodiscard]] constexpr bool test(Char ch_, Context const& ctx) const noexcept
     {
-        return x4::get_case_compare<encoding>(ctx).in_set(ch_, chset);
+        static_assert(noexcept(x4::get_case_compare<encoding_type>(ctx).in_set(ch_, chset)));
+        return x4::get_case_compare<encoding_type>(ctx).in_set(ch_, chset);
     }
 
     detail::basic_chset<char_type> chset;

--- a/include/boost/spirit/x4/char/detail/basic_chset.hpp
+++ b/include/boost/spirit/x4/char/detail/basic_chset.hpp
@@ -132,33 +132,33 @@ struct basic_chset_8bit
     [[nodiscard]] constexpr bool
     test(CharT v) const noexcept
     {
-        return bset.test((unsigned char)v);
+        return bset.test(static_cast<unsigned char>(v));
     }
 
     constexpr void
     set(CharT from, CharT to) noexcept
     {
         for (int i = from; i <= to; ++i)
-            bset.set((unsigned char)i);
+            bset.set(static_cast<unsigned char>(i));
     }
 
     constexpr void
     set(CharT c) noexcept
     {
-        bset.set((unsigned char)c);
+        bset.set(static_cast<unsigned char>(c));
     }
 
     constexpr void
     clear(CharT from, CharT to) noexcept
     {
         for (int i = from; i <= to; ++i)
-            bset.reset((unsigned char)i);
+            bset.reset(static_cast<unsigned char>(i));
     }
 
     constexpr void
     clear(CharT c) noexcept
     {
-        bset.reset((unsigned char)c);
+        bset.reset(static_cast<unsigned char>(c));
     }
 
     constexpr void

--- a/include/boost/spirit/x4/char/negated_char.hpp
+++ b/include/boost/spirit/x4/char/negated_char.hpp
@@ -19,8 +19,10 @@ namespace boost::spirit::x4 {
 
 // `negated_char_parser` handles `~cp`, where `cp` is a `char_parser`
 template<class Positive>
-struct negated_char_parser : char_parser<negated_char_parser<Positive>>
+struct negated_char_parser : char_parser<typename Positive::encoding_type, negated_char_parser<Positive>>
 {
+    using encoding_type = typename Positive::encoding_type;
+
     template<class PositiveT>
         requires
             (!std::is_same_v<std::remove_cvref_t<PositiveT>, negated_char_parser>) &&
@@ -30,9 +32,9 @@ struct negated_char_parser : char_parser<negated_char_parser<Positive>>
         : positive_(std::forward<PositiveT>(positive))
     {}
 
-    template<class CharParam, class Context>
+    template<class CharT, class Context>
     [[nodiscard]] constexpr bool
-    test(CharParam ch, Context const& ctx) const noexcept
+    test(CharT ch, Context const& ctx) const noexcept
     {
         static_assert(noexcept(!positive_.test(ch, ctx)));
         return !positive_.test(ch, ctx);
@@ -47,9 +49,9 @@ private:
     Positive positive_;
 };
 
-template<class Positive>
+template<class Encoding, class Positive>
 [[nodiscard]] constexpr negated_char_parser<Positive>
-operator~(char_parser<Positive> const& cp)
+operator~(char_parser<Encoding, Positive> const& cp)
     noexcept(std::is_nothrow_constructible_v<negated_char_parser<Positive>, Positive const&>)
 {
     return {cp.derived()};

--- a/include/boost/spirit/x4/char_encoding/unicode.hpp
+++ b/include/boost/spirit/x4/char_encoding/unicode.hpp
@@ -19,89 +19,89 @@ namespace boost::spirit::x4::char_encoding {
 struct unicode
 {
     using char_type = char32_t;
-    using classify_type = std::uint32_t;
+    using classify_type = x4::unicode::classify_type;
 
     [[nodiscard]] static constexpr bool
-    isascii_(char_type ch) noexcept
+    isascii_(classify_type ch) noexcept
     {
         return 0 == (ch & ~0x7f);
     }
 
     [[nodiscard]] static constexpr bool
-    ischar(char_type ch) noexcept
+    ischar(classify_type ch) noexcept
     {
         // unicode code points in the range 0x00 to 0x10FFFF
         return ch <= 0x10FFFF;
     }
 
     [[nodiscard]] static constexpr bool
-    isalnum(char_type ch) noexcept
+    isalnum(classify_type ch) noexcept
     {
         return x4::unicode::is_alphanumeric(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isalpha(char_type ch) noexcept
+    isalpha(classify_type ch) noexcept
     {
         return x4::unicode::is_alphabetic(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isdigit(char_type ch) noexcept
+    isdigit(classify_type ch) noexcept
     {
         return x4::unicode::is_decimal_number(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isxdigit(char_type ch) noexcept
+    isxdigit(classify_type ch) noexcept
     {
         return x4::unicode::is_hex_digit(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    iscntrl(char_type ch) noexcept
+    iscntrl(classify_type ch) noexcept
     {
         return x4::unicode::is_control(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isgraph(char_type ch) noexcept
+    isgraph(classify_type ch) noexcept
     {
         return x4::unicode::is_graph(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    islower(char_type ch) noexcept
+    islower(classify_type ch) noexcept
     {
         return x4::unicode::is_lowercase(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isprint(char_type ch) noexcept
+    isprint(classify_type ch) noexcept
     {
         return x4::unicode::is_print(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    ispunct(char_type ch) noexcept
+    ispunct(classify_type ch) noexcept
     {
         return x4::unicode::is_punctuation(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isspace(char_type ch) noexcept
+    isspace(classify_type ch) noexcept
     {
         return x4::unicode::is_white_space(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    (isblank)(char_type ch) noexcept
+    (isblank)(classify_type ch) noexcept
     {
         return x4::unicode::is_blank(ch);
     }
 
     [[nodiscard]] static constexpr bool
-    isupper(char_type ch) noexcept
+    isupper(classify_type ch) noexcept
     {
         return x4::unicode::is_uppercase(ch);
     }
@@ -138,20 +138,20 @@ struct unicode
 
     // Simple character conversions
 
-    [[nodiscard]] static constexpr char_type
-    tolower(char_type ch) noexcept
+    [[nodiscard]] static constexpr classify_type
+    tolower(classify_type ch) noexcept
     {
         return x4::unicode::to_lowercase(ch);
     }
 
-    [[nodiscard]] static constexpr char_type
-    toupper(char_type ch) noexcept
+    [[nodiscard]] static constexpr classify_type
+    toupper(classify_type ch) noexcept
     {
         return x4::unicode::to_uppercase(ch);
     }
 
     [[nodiscard]] static constexpr std::uint32_t
-    toucs4(char_type ch) noexcept
+    toucs4(classify_type ch) noexcept
     {
         return ch;
     }
@@ -166,7 +166,7 @@ struct unicode
     // Major Categories
 #define BOOST_SPIRIT_X4_MAJOR_CATEGORY(name) \
     [[nodiscard]] static constexpr bool \
-    is_##name(char_type ch) noexcept \
+    is_##name(classify_type ch) noexcept \
     { \
         return x4::unicode::get_major_category(ch) == x4::unicode::properties::name; \
     } \
@@ -186,7 +186,7 @@ struct unicode
     // General Categories
 #define BOOST_SPIRIT_X4_CATEGORY(name) \
     [[nodiscard]] static constexpr bool \
-    is_##name(char_type ch) noexcept \
+    is_##name(classify_type ch) noexcept \
     { \
         return x4::unicode::get_category(ch) == x4::unicode::properties::name; \
     } \
@@ -235,7 +235,7 @@ struct unicode
     // Derived Categories
 #define BOOST_SPIRIT_X4_DERIVED_CATEGORY(name) \
     [[nodiscard]] static constexpr bool \
-    is_##name(char_type ch) noexcept \
+    is_##name(classify_type ch) noexcept \
     { \
         return x4::unicode::is_##name(ch); \
     } \
@@ -255,7 +255,7 @@ struct unicode
     // Scripts
 #define BOOST_SPIRIT_X4_SCRIPT(name) \
     [[nodiscard]] static constexpr bool \
-    is_##name(char_type ch) noexcept \
+    is_##name(classify_type ch) noexcept \
     { \
         return x4::unicode::get_script(ch) == x4::unicode::properties::name; \
     } \

--- a/include/boost/spirit/x4/char_encoding/unicode/classification.hpp
+++ b/include/boost/spirit/x4/char_encoding/unicode/classification.hpp
@@ -21,6 +21,8 @@
 
 namespace boost::spirit::x4::unicode {
 
+using classify_type = std::uint32_t;
+
 // This header provides Basic (Level 1) Unicode Support
 // See http://unicode.org/reports/tr18/ for details
 
@@ -263,62 +265,62 @@ enum script
 
 } // properties
 
-[[nodiscard]] constexpr properties::category get_category(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr properties::category get_category(classify_type ch) noexcept
 {
     return static_cast<properties::category>(detail::category_lookup(ch) & 0x3F);
 }
 
-[[nodiscard]] constexpr properties::major_category get_major_category(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr properties::major_category get_major_category(classify_type ch) noexcept
 {
     return static_cast<properties::major_category>(unicode::get_category(ch) >> 3);
 }
 
-[[nodiscard]] constexpr bool is_punctuation(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_punctuation(classify_type ch) noexcept
 {
     return unicode::get_major_category(ch) == properties::punctuation;
 }
 
-[[nodiscard]] constexpr bool is_decimal_number(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_decimal_number(classify_type ch) noexcept
 {
     return unicode::get_category(ch) == properties::decimal_number;
 }
 
-[[nodiscard]] constexpr bool is_hex_digit(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_hex_digit(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::hex_digit) != 0;
 }
 
-[[nodiscard]] constexpr bool is_control(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_control(classify_type ch) noexcept
 {
     return unicode::get_category(ch) == properties::control;
 }
 
-[[nodiscard]] constexpr bool is_alphabetic(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_alphabetic(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::alphabetic) != 0;
 }
 
-[[nodiscard]] constexpr bool is_alphanumeric(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_alphanumeric(classify_type ch) noexcept
 {
     return unicode::is_decimal_number(ch) || unicode::is_alphabetic(ch);
 }
 
-[[nodiscard]] constexpr bool is_uppercase(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_uppercase(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::uppercase) != 0;
 }
 
-[[nodiscard]] constexpr bool is_lowercase(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_lowercase(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::lowercase) != 0;
 }
 
-[[nodiscard]] constexpr bool is_white_space(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_white_space(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::white_space) != 0;
 }
 
-[[nodiscard]] constexpr bool is_blank(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_blank(classify_type ch) noexcept
 {
     switch (ch)
     {
@@ -333,7 +335,7 @@ enum script
     }
 }
 
-[[nodiscard]] constexpr bool is_graph(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_graph(classify_type ch) noexcept
 {
     return !(
         unicode::is_white_space(ch) ||
@@ -343,37 +345,37 @@ enum script
     );
 }
 
-[[nodiscard]] constexpr bool is_print(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_print(classify_type ch) noexcept
 {
     return (unicode::is_graph(ch) || unicode::is_blank(ch)) && !unicode::is_control(ch);
 }
 
-[[nodiscard]] constexpr bool is_noncharacter_code_point(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_noncharacter_code_point(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::noncharacter_code_point) != 0;
 }
 
-[[nodiscard]] constexpr bool is_default_ignorable_code_point(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr bool is_default_ignorable_code_point(classify_type ch) noexcept
 {
     return (detail::category_lookup(ch) & properties::default_ignorable_code_point) != 0;
 }
 
-[[nodiscard]] constexpr properties::script get_script(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr properties::script get_script(classify_type ch) noexcept
 {
     return static_cast<properties::script>(detail::script_lookup(ch));
 }
 
-[[nodiscard]] constexpr std::uint32_t to_lowercase(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr classify_type to_lowercase(classify_type ch) noexcept
 {
     // The table returns 0 to signal that this code maps to itself
-    std::uint32_t const r = detail::lowercase_lookup(ch);
+    classify_type const r = detail::lowercase_lookup(ch);
     return r == 0 ? ch : r;
 }
 
-[[nodiscard]] constexpr std::uint32_t to_uppercase(std::uint32_t ch) noexcept
+[[nodiscard]] constexpr classify_type to_uppercase(classify_type ch) noexcept
 {
     // The table returns 0 to signal that this code maps to itself
-    std::uint32_t const r = detail::uppercase_lookup(ch);
+    classify_type const r = detail::uppercase_lookup(ch);
     return r == 0 ? ch : r;
 }
 

--- a/include/boost/spirit/x4/core/move_to.hpp
+++ b/include/boost/spirit/x4/core/move_to.hpp
@@ -47,7 +47,7 @@ template<traits::NonUnusedAttr T>
 constexpr void move_to(T&& src, T& dest)
     noexcept(std::is_nothrow_assignable_v<T&, T&&>)
 {
-    dest = std::move(src);
+    dest = std::forward<T>(src);
 }
 
 template<traits::NonUnusedAttr T>
@@ -88,7 +88,7 @@ constexpr void move_to(Source&&, Dest&) noexcept
 }
 
 template<std::forward_iterator It, std::sentinel_for<It> Se>
-constexpr void move_to(It const&, Se const&, unused_container_type const&)
+constexpr void move_to(It const&, Se const&, unused_container_type const&) noexcept
 {
     // unused attribute
 }
@@ -237,7 +237,7 @@ move_to(It first, Se last, Dest& dest)
     x4::move_to(first, last, fusion::front(dest));
 }
 
-template<traits::ContainerAttr Source, traits::CategorizedAttr<traits::container_attr> Dest>
+template<traits::X4Container Source, traits::CategorizedAttr<traits::container_attr> Dest>
 constexpr void
 move_to(Source&& src, Dest& dest)
     // TODO: noexcept

--- a/include/boost/spirit/x4/numeric/bool.hpp
+++ b/include/boost/spirit/x4/numeric/bool.hpp
@@ -33,7 +33,7 @@ struct bool_policies
         noexcept(std::is_nothrow_constructible_v<Attr, T>)
     {
         using namespace std::string_view_literals;
-        if (detail::string_parse("true"sv, first, last, unused, case_compare)) {
+        if (detail::string_parse("true"sv, first, last, unused_container, case_compare)) {
             x4::move_to(T(true), attr_);    // result is true
             return true;
         }
@@ -46,7 +46,7 @@ struct bool_policies
         noexcept(std::is_nothrow_constructible_v<Attr, T>)
     {
         using namespace std::string_view_literals;
-        if (detail::string_parse("false"sv, first, last, unused, case_compare)) {
+        if (detail::string_parse("false"sv, first, last, unused_container, case_compare)) {
             x4::move_to(T(false), attr_);   // result is false
             return true;
         }

--- a/include/boost/spirit/x4/numeric/real.hpp
+++ b/include/boost/spirit/x4/numeric/real.hpp
@@ -114,7 +114,7 @@ struct ureal_policies
         if (*first != 'n' && *first != 'N') return false;   // not "nan"
 
         // nan[(...)] ?
-        if (detail::string_parse("nan"sv, "NAN"sv, first, last, unused)) {
+        if (detail::string_parse("nan"sv, "NAN"sv, first, last, unused_container)) {
             if (first != last && *first == '(') {
                 // skip trailing (...) part
                 It i = first;
@@ -142,9 +142,9 @@ struct ureal_policies
         if (*first != 'i' && *first != 'I') return false;   // not "inf"
 
         // inf or infinity ?
-        if (detail::string_parse("inf"sv, "INF"sv, first, last, unused)) {
+        if (detail::string_parse("inf"sv, "INF"sv, first, last, unused_container)) {
             // skip allowed 'inity' part of infinity
-            (void)detail::string_parse("inity"sv, "INITY"sv, first, last, unused);
+            (void)detail::string_parse("inity"sv, "INITY"sv, first, last, unused_container);
             attr_ = std::numeric_limits<T>::infinity();
             return true;
         }

--- a/include/boost/spirit/x4/string/detail/string_parse.hpp
+++ b/include/boost/spirit/x4/string/detail/string_parse.hpp
@@ -10,9 +10,14 @@
 ==============================================================================*/
 
 #include <boost/spirit/x4/core/move_to.hpp>
+#include <boost/spirit/x4/traits/string_traits.hpp>
+#include <boost/spirit/x4/traits/tuple_traits.hpp>
+#include <boost/spirit/x4/traits/container_traits.hpp>
 
+#include <concepts>
 #include <string_view>
 #include <iterator>
+#include <type_traits>
 
 namespace boost::spirit::x4::detail {
 
@@ -22,22 +27,35 @@ string_parse(
     std::basic_string_view<CharT, CharTraitsT> const str,
     It& first, Se const& last,
     Attr& attr, CaseCompareFunc const& compare
-) noexcept(std::is_same_v<std::remove_const_t<Attr>, unused_type>)
+) noexcept(std::same_as<std::remove_const_t<Attr>, unused_container_type>)
 {
-    It i = first;
+    using synthesized_value_type = traits::synthesized_value_t<Attr>;
+    static_assert(std::same_as<traits::attribute_category_t<synthesized_value_type>, traits::container_attr>);
+    using value_type = traits::container_value_t<synthesized_value_type>;
+    static_assert(!traits::CharLike<value_type> || std::same_as<value_type, CharT>, "Mixing incompatible char types is not allowed");
+
+    It it = first;
     auto stri = str.begin();
     auto str_last = str.end();
 
-    for (; stri != str_last; ++stri, ++i) {
-        if (i == last || compare(*stri, *i) != 0) {
+    for (; stri != str_last; ++stri, ++it) {
+        if (it == last || compare(*stri, *it) != 0) {
             return false;
         }
     }
 
-    x4::move_to(first, i, x4::assume_container(attr));
-    first = i;
+    x4::move_to(first, it, attr);
+    first = it;
     return true;
 }
+
+template<class CharT, class CharTraitsT, std::forward_iterator It, std::sentinel_for<It> Se, class CaseCompareFunc>
+constexpr void
+string_parse(
+    std::basic_string_view<CharT, CharTraitsT> const,
+    It&, Se const&,
+    unused_type const&, CaseCompareFunc const&
+) = delete; // The call site is lacking `x4::assume_container(attr)`
 
 template<class CharT, class CharTraitsT, std::forward_iterator It, std::sentinel_for<It> Se, X4Attribute Attr, class CaseCompareFunc>
 [[nodiscard]] constexpr bool
@@ -45,7 +63,7 @@ string_parse(
     std::basic_string<CharT, CharTraitsT> const& str,
     It& first, Se const& last,
     Attr& attr, CaseCompareFunc const& compare
-) noexcept(std::is_same_v<std::remove_const_t<Attr>, unused_type>)
+) noexcept(noexcept(detail::string_parse(std::basic_string_view{str}, first, last, attr, compare)))
 {
     return detail::string_parse(std::basic_string_view{str}, first, last, attr, compare);
 }
@@ -56,20 +74,25 @@ string_parse(
     std::basic_string_view<CharT, CharTraitsT> const ucstr,
     std::basic_string_view<CharT, CharTraitsT> const lcstr,
     It& first, Se const& last, Attr& attr
-) noexcept(std::is_same_v<std::remove_const_t<Attr>, unused_type>)
+) noexcept(std::same_as<std::remove_const_t<Attr>, unused_container_type>)
 {
-    auto uc_i = ucstr.begin();
-    auto uc_last = ucstr.end();
-    auto lc_i = lcstr.begin();
-    It i = first;
+    using synthesized_value_type = traits::synthesized_value_t<Attr>;
+    static_assert(std::same_as<traits::attribute_category_t<synthesized_value_type>, traits::container_attr>);
+    using value_type = traits::container_value_t<synthesized_value_type>;
+    static_assert(!traits::CharLike<value_type> || std::same_as<value_type, CharT>, "Mixing incompatible char types is not allowed");
 
-    for (; uc_i != uc_last; ++uc_i, ++lc_i, ++i) {
-        if (i == last || (*uc_i != *i && *lc_i != *i)) {
+    auto uc_it = ucstr.begin();
+    auto uc_last = ucstr.end();
+    auto lc_it = lcstr.begin();
+    It it = first;
+
+    for (; uc_it != uc_last; ++uc_it, ++lc_it, ++it) {
+        if (it == last || (*uc_it != *it && *lc_it != *it)) {
             return false;
         }
     }
-    x4::move_to(first, i, x4::assume_container(attr));
-    first = i;
+    x4::move_to(first, it, attr);
+    first = it;
     return true;
 }
 
@@ -79,10 +102,18 @@ string_parse(
     std::basic_string<CharT, CharTraitsT> const& ucstr,
     std::basic_string<CharT, CharTraitsT> const& lcstr,
     It& first, Se const& last, Attr& attr
-) noexcept(std::is_same_v<std::remove_const_t<Attr>, unused_type>)
+) noexcept(noexcept(detail::string_parse(std::basic_string_view{ucstr}, std::basic_string_view{lcstr}, first, last, attr)))
 {
     return detail::string_parse(std::basic_string_view{ucstr}, std::basic_string_view{lcstr}, first, last, attr);
 }
+
+template<class CharT, class CharTraitsT, std::forward_iterator It, std::sentinel_for<It> Se>
+[[nodiscard]] constexpr bool
+string_parse(
+    std::basic_string_view<CharT, CharTraitsT> const,
+    std::basic_string_view<CharT, CharTraitsT> const,
+    It&, Se const&, unused_type const&
+) = delete; // The call site is lacking `x4::assume_container(attr)`
 
 } // boost::spirit::x4::detail
 

--- a/include/boost/spirit/x4/string/detail/tst_node.hpp
+++ b/include/boost/spirit/x4/string/detail/tst_node.hpp
@@ -100,29 +100,31 @@ struct tst_node
             &tst_node::node_alloc,
             &tst_node::lt, &tst_node::eq, &tst_node::gt
         >(*this, std::move(rhs));
+
+        return *this;
     }
 
-    template<std::forward_iterator Iterator, class CaseCompare>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class CaseCompare>
     [[nodiscard]] static constexpr T*
-    find(tst_node* start, Iterator& first, Iterator last, CaseCompare const& comp) noexcept
+    find(tst_node* start, It& first, Se const& last, CaseCompare const& comp) noexcept
     {
         if (first == last) return nullptr;
 
-        Iterator i = first;
-        Iterator latest = first;
+        It it = first;
+        It latest = first;
         tst_node* p = start;
         T* found = nullptr;
 
-        while (p && i != last) {
-            auto c = comp(*i,p->id);
+        while (p && it != last) {
+            auto c = comp(*it, p->id);
 
             if (c == 0) {
                 if (p->data) {
                     found = p->data;
-                    latest = i;
+                    latest = it;
                 }
                 p = p->eq;
-                ++i;
+                ++it;
 
             } else if (c < 0) {
                 p = p->lt;

--- a/include/boost/spirit/x4/string/tst.hpp
+++ b/include/boost/spirit/x4/string/tst.hpp
@@ -84,14 +84,14 @@ struct tst
         return *this;
     }
 
-    template<std::forward_iterator Iterator, class CaseCompare>
-    [[nodiscard]] constexpr T* find(Iterator& first, Iterator last, CaseCompare caseCompare) const noexcept
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class CaseCompare>
+    [[nodiscard]] constexpr T* find(It& first, Se const& last, CaseCompare const& compare) const noexcept
     {
-        return node::find(root_, first, last, caseCompare);
+        return node::find(root_, first, last, compare);
     }
 
-    template<std::forward_iterator Iterator, class Val>
-    constexpr T* add(Iterator first, Iterator last, Val&& val)
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Val>
+    constexpr T* add(It first, Se last, Val&& val)
     {
         if (first == last) return nullptr;
         if (!root_) {
@@ -102,8 +102,8 @@ struct tst
         return this->add(root_, first, last, std::forward<Val>(val));
     }
 
-    template<std::forward_iterator Iterator>
-    constexpr void remove(Iterator first, Iterator last) noexcept
+    template<std::forward_iterator It, std::sentinel_for<It> Se>
+    constexpr void remove(It first, Se last) noexcept
     {
         this->remove(root_, first, last);
     }
@@ -125,9 +125,9 @@ struct tst
     friend struct allocator_ops<tst>;
 
 private:
-    template<std::forward_iterator Iterator, class Val>
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Val>
     [[nodiscard]] constexpr T*
-    add(node* root, Iterator first, Iterator last, Val&& val)
+    add(node* root, It first, Se const last, Val&& val)
     {
         assert(root != nullptr);
         assert(first != last);
@@ -162,9 +162,9 @@ private:
         }
     }
 
-    template<std::forward_iterator Iterator>
+    template<std::forward_iterator It, std::sentinel_for<It> Se>
     constexpr void
-    remove(node*& p, Iterator first, Iterator last) noexcept
+    remove(node*& p, It first, Se const last) noexcept
     {
         if (!p || first == last) return;
 

--- a/include/boost/spirit/x4/traits/container_traits.hpp
+++ b/include/boost/spirit/x4/traits/container_traits.hpp
@@ -406,7 +406,7 @@ template<class T>
 constexpr bool is_container_v = is_container<T>::value;
 
 template<class T>
-concept ContainerAttr = is_container_v<std::remove_cvref_t<T>>;
+concept X4Container = is_container_v<std::remove_cvref_t<T>>;
 
 // -------------------------------------------------
 

--- a/include/boost/spirit/x4/traits/string_traits.hpp
+++ b/include/boost/spirit/x4/traits/string_traits.hpp
@@ -98,7 +98,7 @@ concept CppStringLike =
 template<class T, class ExpectedCharT>
 concept CharIncompatibleWith =
     CharLike<T> &&
-    !std::same_as<std::remove_cvref_t<T>, ExpectedCharT>;
+    !std::same_as<T, ExpectedCharT>;
 
 // Mixing incompatible character types is semantically wrong.
 // Don't do that. It may even lead to security vulnerabilities.

--- a/include/boost/spirit/x4/traits/tuple_traits.hpp
+++ b/include/boost/spirit/x4/traits/tuple_traits.hpp
@@ -12,6 +12,7 @@
 #include <boost/fusion/support/is_sequence.hpp>
 #include <boost/fusion/include/is_view.hpp>
 #include <boost/fusion/include/size.hpp>
+#include <boost/fusion/include/front.hpp>
 
 #include <type_traits>
 
@@ -69,6 +70,23 @@ struct is_size_one_view
 
 template<class View>
 constexpr bool is_size_one_view_v = is_size_one_view<View>::value;
+
+
+template<class T>
+struct synthesized_value
+{
+    using type = T;
+};
+
+template<class T>
+using synthesized_value_t = typename synthesized_value<T>::type;
+
+template<class T>
+    requires is_size_one_sequence_v<std::remove_cvref_t<T>>
+struct synthesized_value<T>
+{
+    using type = std::remove_cvref_t<typename fusion::result_of::front<T>::type>;
+};
 
 } // boost::spirit::x4::traits
 

--- a/test/x4/bool.cpp
+++ b/test/x4/bool.cpp
@@ -26,7 +26,7 @@ struct backwards_bool_policies : x4::bool_policies<>
     {
         using namespace std::string_view_literals;
         namespace x4 = boost::spirit::x4;
-        if (x4::detail::string_parse("eurt"sv, first, last, x4::unused, case_compare)) {
+        if (x4::detail::string_parse("eurt"sv, first, last, unused_container, case_compare)) {
             x4::move_to(false, attr);   // result is false
             return true;
         }

--- a/test/x4/char_class.cpp
+++ b/test/x4/char_class.cpp
@@ -22,6 +22,23 @@
 int main()
 {
     {
+        std::string_view sv;
+        auto first = sv.begin();
+        auto const last = sv.end();
+        char ch{};
+        static_assert(noexcept(x4::standard::alnum.parse(first, last, unused, ch)));
+        (void)x4::standard::alnum.parse(first, last, unused, ch);
+    }
+    {
+        std::u32string_view sv;
+        auto first = sv.begin();
+        auto const last = sv.end();
+        char32_t ch{};
+        static_assert(noexcept(x4::unicode::alnum.parse(first, last, unused, ch)));
+        (void)x4::unicode::alnum.parse(first, last, unused, ch);
+    }
+
+    {
         using namespace x4::standard;
         BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(alnum);
         BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(alpha);

--- a/test/x4/test.hpp
+++ b/test/x4/test.hpp
@@ -28,6 +28,8 @@ namespace x4 = spirit::x4;
 
 using x4::unused_type;
 using x4::unused;
+using x4::unused_container_type;
+using x4::unused_container;
 
 namespace spirit_test {
 

--- a/test/x4/tst.cpp
+++ b/test/x4/tst.cpp
@@ -42,7 +42,7 @@ void docheck(TST const& tst, CaseCompare const& comp, Char const* s, bool const 
     Char const* first = s;
     Char const* last = s;
     while (*last) ++last;
-    int* r = tst.find(s, last,comp);
+    int* r = tst.find(s, last, comp);
     BOOST_TEST(!!r == expected);
 
     if (r) {


### PR DESCRIPTION
Part of #4 

I implemented basic checks to forbid mixture of incompatible char types (e.g. `char`/`wchar_t`, `char`/`char32_t`) in boostorg/spirit#817. This PR adds more checks which were previously missing.

In fact, some of our unit tests were actually doing this mistake and they're fixed now.