### PR TITLE
Reduce the number of identifiers in top-level `x4::` scope

### DIFF
--- a/include/boost/spirit/x4/ast/position_tagged.hpp
+++ b/include/boost/spirit/x4/ast/position_tagged.hpp
@@ -9,10 +9,14 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ==============================================================================*/
 
+#include <boost/spirit/x4/core/attribute.hpp>
+
 #include <concepts>
 #include <ranges>
 
 namespace boost::spirit::x4 {
+
+namespace ast {
 
 struct position_tagged
 {
@@ -34,41 +38,41 @@ public:
         , last_(last)
     {}
 
-    template<class AST>
-        requires std::derived_from<AST, position_tagged>
+    template<X4Attribute Attr>
+        requires std::derived_from<Attr, position_tagged>
     [[nodiscard]] std::ranges::subrange<iterator_type>
-    position_of(AST const& ast) const
+    position_of(Attr const& attr) const
     {
         return std::ranges::subrange<iterator_type>{
-            positions_.at(ast.id_first),
-            positions_.at(ast.id_last)
+            positions_.at(attr.id_first),
+            positions_.at(attr.id_last)
         };
     }
 
-    template<class AST>
-        requires (!std::derived_from<AST, position_tagged>)
+    template<X4Attribute Attr>
+        requires (!std::derived_from<Attr, position_tagged>)
     [[nodiscard]] std::ranges::subrange<iterator_type>
-    position_of(AST const&) const
+    position_of(Attr const&) const
     {
         // returns an empty position
         return std::ranges::subrange<iterator_type>{};
     }
 
     // This will catch all nodes except those inheriting from position_tagged
-    template<class AST>
-        requires (!std::derived_from<AST, position_tagged>)
-    void annotate(AST&, iterator_type const&, iterator_type const&)
+    template<X4Attribute Attr>
+        requires (!std::derived_from<Attr, position_tagged>)
+    static void annotate(Attr&, iterator_type const&, iterator_type const&)
     {
         // (no-op) no need for tags
     }
 
-    template<class AST>
-        requires std::derived_from<AST, position_tagged>
-    void annotate(AST& ast, iterator_type first, iterator_type last)
+    template<X4Attribute Attr>
+        requires std::derived_from<Attr, position_tagged>
+    void annotate(Attr& attr, iterator_type first, iterator_type last)
     {
-        ast.id_first = int(positions_.size());
+        attr.id_first = static_cast<int>(positions_.size());
         positions_.push_back(std::move(first));
-        ast.id_last = int(positions_.size());
+        attr.id_last = static_cast<int>(positions_.size());
         positions_.push_back(std::move(last));
     }
 
@@ -86,6 +90,13 @@ private:
     iterator_type first_;
     iterator_type last_;
 };
+
+} // ast
+
+using position_tagged [[deprecated("Use `ast::`")]] = ast::position_tagged;
+
+template<class Container>
+using position_cache [[deprecated("Use `ast::`")]] = ast::position_cache<Container>;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/auxiliary/attr.hpp
+++ b/include/boost/spirit/x4/auxiliary/attr.hpp
@@ -94,11 +94,13 @@ struct attr_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers {
 
 inline constexpr detail::attr_gen attr{};
 
-} // cpos
+} // parsers
+
+using parsers::attr;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/auxiliary/eoi.hpp
+++ b/include/boost/spirit/x4/auxiliary/eoi.hpp
@@ -44,11 +44,13 @@ struct get_info<eoi_parser>
     [[nodiscard]] result_type operator()(eoi_parser const &) const { return "eoi"; }
 };
 
-inline namespace cpos {
+namespace parsers {
 
 inline constexpr eoi_parser eoi{};
 
-} // cpos
+} // parsers
+
+using parsers::eoi;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/auxiliary/eol.hpp
+++ b/include/boost/spirit/x4/auxiliary/eol.hpp
@@ -56,11 +56,13 @@ struct get_info<eol_parser>
     [[nodiscard]] result_type operator()(eol_parser const &) const { return "eol"; }
 };
 
-inline namespace cpos {
+namespace parsers {
 
 inline constexpr eol_parser eol{};
 
-} // cpos
+} // parsers
+
+using parsers::eol;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/auxiliary/eps.hpp
+++ b/include/boost/spirit/x4/auxiliary/eps.hpp
@@ -118,11 +118,13 @@ struct eps_parser : parser<eps_parser>
     }
 };
 
-inline namespace cpos {
+namespace parsers {
 
 [[maybe_unused]] inline constexpr eps_parser eps{};
 
-} // cpos
+} // parsers
+
+using parsers::eps;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/binary.hpp
+++ b/include/boost/spirit/x4/binary.hpp
@@ -112,11 +112,12 @@ struct any_binary_parser : parser<any_binary_parser<T, endian, bits>>
     }
 };
 
-inline namespace cpos {
 
 #define BOOST_SPIRIT_X4_BINARY_PARSER(name, endiantype, attrtype, bits) \
-    using name##type = any_binary_parser<attrtype, boost::endian::order::endiantype, bits>; \
-    inline constexpr name##type name{};
+    namespace parsers { \
+    inline constexpr any_binary_parser<attrtype, boost::endian::order::endiantype, bits> name{}; \
+    } /* parsers */ \
+    using parsers::name;
 
 BOOST_SPIRIT_X4_BINARY_PARSER(byte_, native, uint_least8_t, 8)
 BOOST_SPIRIT_X4_BINARY_PARSER(word, native, uint_least16_t, 16)
@@ -141,7 +142,6 @@ BOOST_SPIRIT_X4_BINARY_PARSER(little_bin_double, little, double, sizeof(double) 
 
 #undef BOOST_SPIRIT_X4_BINARY_PARSER
 
-} // cpos
 
 template<class T, std::size_t bits>
 struct get_info<any_binary_parser<T, endian::order::little, bits>>

--- a/include/boost/spirit/x4/char/char.hpp
+++ b/include/boost/spirit/x4/char/char.hpp
@@ -122,6 +122,33 @@ using unicode::helpers::lit;
 #endif // BOOST_SPIRIT_X4_UNICODE
 
 
+namespace parsers {
+
+namespace standard {
+using x4::standard::char_;
+using x4::standard::lit;
+} // standard
+
+#ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
+namespace standard_wide {
+using x4::standard_wide::char_;
+using x4::standard_wide::lit;
+} // standard_wide
+#endif
+
+#ifdef BOOST_SPIRIT_X4_UNICODE
+namespace unicode {
+using x4::unicode::char_;
+using x4::unicode::lit;
+} // standard_wide
+#endif
+
+using x4::char_; // TODO: make `any_parser` encoding-agnostic
+using x4::lit;
+
+} // parsers
+
+
 namespace extension {
 
 template<>

--- a/include/boost/spirit/x4/char/char_class.hpp
+++ b/include/boost/spirit/x4/char/char_class.hpp
@@ -87,8 +87,7 @@ struct char_class_parser : char_parser<Encoding, char_class_parser<Encoding, Tag
 };
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(encoding, name) \
-    using name##_type = char_class_parser<char_encoding::encoding, char_classes::name##_tag>; \
-    inline constexpr name##_type name{};
+    inline constexpr char_class_parser<char_encoding::encoding, char_classes::name##_tag> name{};
 
 #define BOOST_SPIRIT_X4_CHAR_CLASSES(encoding) \
     namespace encoding \
@@ -115,19 +114,6 @@ BOOST_SPIRIT_X4_CHAR_CLASSES(standard_wide)
 
 #undef BOOST_SPIRIT_X4_CHAR_CLASS
 #undef BOOST_SPIRIT_X4_CHAR_CLASSES
-
-using alnum_type  = standard::alnum_type;
-using alpha_type  = standard::alpha_type;
-using digit_type  = standard::digit_type;
-using xdigit_type = standard::xdigit_type;
-using cntrl_type  = standard::cntrl_type;
-using graph_type  = standard::graph_type;
-using lower_type  = standard::lower_type;
-using print_type  = standard::print_type;
-using punct_type  = standard::punct_type;
-using space_type  = standard::space_type;
-using blank_type  = standard::blank_type;
-using upper_type  = standard::upper_type;
 
 inline constexpr auto const& alnum  = standard::alnum;
 inline constexpr auto const& alpha  = standard::alpha;

--- a/include/boost/spirit/x4/char/char_class.hpp
+++ b/include/boost/spirit/x4/char/char_class.hpp
@@ -37,7 +37,7 @@ struct char_class_base
 #define BOOST_SPIRIT_X4_CLASSIFY(name) \
     template<class Char> \
     [[nodiscard]] static constexpr bool \
-    is(name##_tag, Char ch) noexcept \
+    is(char_classes::name##_tag, Char ch) noexcept \
     { \
         static_assert(std::same_as<Char, classify_type>); \
         return (Encoding::is##name)(detail::cast_char<classify_type>(ch)); \
@@ -87,7 +87,7 @@ struct char_class_parser : char_parser<Encoding, char_class_parser<Encoding, Tag
 };
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(encoding, name) \
-    using name##_type = char_class_parser<char_encoding::encoding, name##_tag>; \
+    using name##_type = char_class_parser<char_encoding::encoding, char_classes::name##_tag>; \
     inline constexpr name##_type name{};
 
 #define BOOST_SPIRIT_X4_CHAR_CLASSES(encoding) \

--- a/include/boost/spirit/x4/char/char_class.hpp
+++ b/include/boost/spirit/x4/char/char_class.hpp
@@ -87,24 +87,26 @@ struct char_class_parser : char_parser<Encoding, char_class_parser<Encoding, Tag
 };
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(encoding, name) \
-    inline constexpr char_class_parser<char_encoding::encoding, char_classes::name##_tag> name{};
+    namespace encoding { \
+    inline constexpr char_class_parser<char_encoding::encoding, char_classes::name##_tag> name{}; \
+    } /* encoding */ \
+    namespace parsers::encoding { \
+    using x4::encoding::name; \
+    } /* parsers::encoding */
 
 #define BOOST_SPIRIT_X4_CHAR_CLASSES(encoding) \
-    namespace encoding \
-    { \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, alnum) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, alpha) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, digit) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, xdigit) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, cntrl) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, graph) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, lower) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, print) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, punct) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, space) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, blank) \
-        BOOST_SPIRIT_X4_CHAR_CLASS(encoding, upper) \
-    } /* encoding */
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, alnum) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, alpha) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, digit) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, xdigit) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, cntrl) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, graph) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, lower) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, print) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, punct) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, space) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, blank) \
+    BOOST_SPIRIT_X4_CHAR_CLASS(encoding, upper)
 
 BOOST_SPIRIT_X4_CHAR_CLASSES(standard)
 
@@ -115,18 +117,20 @@ BOOST_SPIRIT_X4_CHAR_CLASSES(standard_wide)
 #undef BOOST_SPIRIT_X4_CHAR_CLASS
 #undef BOOST_SPIRIT_X4_CHAR_CLASSES
 
-inline constexpr auto const& alnum  = standard::alnum;
-inline constexpr auto const& alpha  = standard::alpha;
-inline constexpr auto const& digit  = standard::digit;
-inline constexpr auto const& xdigit = standard::xdigit;
-inline constexpr auto const& cntrl  = standard::cntrl;
-inline constexpr auto const& graph  = standard::graph;
-inline constexpr auto const& lower  = standard::lower;
-inline constexpr auto const& print  = standard::print;
-inline constexpr auto const& punct  = standard::punct;
-inline constexpr auto const& space  = standard::space;
-inline constexpr auto const& blank  = standard::blank;
-inline constexpr auto const& upper  = standard::upper;
+// Don't put these in namespace `parsers`, these are too much
+
+using x4::standard::alnum;
+using x4::standard::alpha;
+using x4::standard::digit;
+using x4::standard::xdigit;
+using x4::standard::cntrl;
+using x4::standard::graph;
+using x4::standard::lower;
+using x4::standard::print;
+using x4::standard::punct;
+using x4::standard::space;
+using x4::standard::blank;
+using x4::standard::upper;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/char/char_class_tags.hpp
+++ b/include/boost/spirit/x4/char/char_class_tags.hpp
@@ -11,6 +11,8 @@
 
 namespace boost::spirit::x4 {
 
+namespace char_classes {
+
 struct char_tag {};
 struct alnum_tag {};
 struct alpha_tag {};
@@ -24,6 +26,8 @@ struct space_tag {};
 struct xdigit_tag {};
 struct lower_tag {};
 struct upper_tag {};
+
+} // char_classes
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/char/unicode_char_class.hpp
+++ b/include/boost/spirit/x4/char/unicode_char_class.hpp
@@ -19,6 +19,7 @@ namespace boost::spirit::x4 {
 namespace char_classes::unicode {
 
 // Common Categories (semantically compatible with `standard::*` variants)
+
 using char_tag = char_classes::char_tag;
 using alnum_tag = char_classes::alnum_tag;
 using alpha_tag = char_classes::alpha_tag;
@@ -34,6 +35,7 @@ using blank_tag = char_classes::blank_tag;
 using upper_tag = char_classes::upper_tag;
 
 // Unicode Major Categories
+
 struct letter_tag {};
 struct mark_tag {};
 struct number_tag {};
@@ -43,6 +45,7 @@ struct punctuation_tag {};
 struct symbol_tag {};
 
 // Unicode General Categories
+
 struct uppercase_letter_tag {};
 struct lowercase_letter_tag {};
 struct titlecase_letter_tag {};
@@ -81,6 +84,7 @@ struct modifier_symbol_tag {};
 struct other_symbol_tag {};
 
 // Unicode Derived Categories
+
 struct alphabetic_tag {};
 struct uppercase_tag {};
 struct lowercase_tag {};
@@ -90,6 +94,7 @@ struct noncharacter_code_point_tag {};
 struct default_ignorable_code_point_tag {};
 
 // Unicode Scripts
+
 struct adlam_tag {};
 struct caucasian_albanian_tag {};
 struct ahom_tag {};
@@ -281,8 +286,8 @@ struct unicode_char_class_base
         return (encoding_type::is_##name)(detail::cast_char<char_type>(ch)); \
     }
 
-
     // Unicode Major Categories
+
     BOOST_SPIRIT_X4_BASIC_CLASSIFY(char)
     BOOST_SPIRIT_X4_BASIC_CLASSIFY(alnum)
     BOOST_SPIRIT_X4_BASIC_CLASSIFY(alpha)
@@ -298,6 +303,7 @@ struct unicode_char_class_base
     BOOST_SPIRIT_X4_BASIC_CLASSIFY(upper)
 
     // Unicode Major Categories
+
     BOOST_SPIRIT_X4_CLASSIFY(letter)
     BOOST_SPIRIT_X4_CLASSIFY(mark)
     BOOST_SPIRIT_X4_CLASSIFY(number)
@@ -307,6 +313,7 @@ struct unicode_char_class_base
     BOOST_SPIRIT_X4_CLASSIFY(symbol)
 
     // Unicode General Categories
+
     BOOST_SPIRIT_X4_CLASSIFY(uppercase_letter)
     BOOST_SPIRIT_X4_CLASSIFY(lowercase_letter)
     BOOST_SPIRIT_X4_CLASSIFY(titlecase_letter)
@@ -345,6 +352,7 @@ struct unicode_char_class_base
     BOOST_SPIRIT_X4_CLASSIFY(other_symbol)
 
     // Unicode Derived Categories
+
     BOOST_SPIRIT_X4_CLASSIFY(alphabetic)
     BOOST_SPIRIT_X4_CLASSIFY(uppercase)
     BOOST_SPIRIT_X4_CLASSIFY(lowercase)
@@ -354,6 +362,7 @@ struct unicode_char_class_base
     BOOST_SPIRIT_X4_CLASSIFY(default_ignorable_code_point)
 
     // Unicode Scripts
+
     BOOST_SPIRIT_X4_CLASSIFY(adlam)
     BOOST_SPIRIT_X4_CLASSIFY(caucasian_albanian)
     BOOST_SPIRIT_X4_CLASSIFY(ahom)
@@ -547,12 +556,12 @@ struct unicode_char_class : char_parser<char_encoding::unicode, unicode_char_cla
 };
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(name) \
-    using name##_type = unicode_char_class<char_classes::unicode::name##_tag>; \
-    inline constexpr name##_type name{};
+    inline constexpr unicode_char_class<char_classes::unicode::name##_tag> name{};
 
 namespace unicode {
 
 // Unicode Major Categories
+
 BOOST_SPIRIT_X4_CHAR_CLASS(alnum)
 BOOST_SPIRIT_X4_CHAR_CLASS(alpha)
 BOOST_SPIRIT_X4_CHAR_CLASS(digit)
@@ -567,6 +576,7 @@ BOOST_SPIRIT_X4_CHAR_CLASS(blank)
 BOOST_SPIRIT_X4_CHAR_CLASS(upper)
 
 // Unicode Major Categories
+
 BOOST_SPIRIT_X4_CHAR_CLASS(letter)
 BOOST_SPIRIT_X4_CHAR_CLASS(mark)
 BOOST_SPIRIT_X4_CHAR_CLASS(number)
@@ -576,6 +586,7 @@ BOOST_SPIRIT_X4_CHAR_CLASS(punctuation)
 BOOST_SPIRIT_X4_CHAR_CLASS(symbol)
 
 // Unicode General Categories
+
 BOOST_SPIRIT_X4_CHAR_CLASS(uppercase_letter)
 BOOST_SPIRIT_X4_CHAR_CLASS(lowercase_letter)
 BOOST_SPIRIT_X4_CHAR_CLASS(titlecase_letter)
@@ -614,6 +625,7 @@ BOOST_SPIRIT_X4_CHAR_CLASS(modifier_symbol)
 BOOST_SPIRIT_X4_CHAR_CLASS(other_symbol)
 
 // Unicode Derived Categories
+
 BOOST_SPIRIT_X4_CHAR_CLASS(alphabetic)
 BOOST_SPIRIT_X4_CHAR_CLASS(uppercase)
 BOOST_SPIRIT_X4_CHAR_CLASS(lowercase)
@@ -623,6 +635,7 @@ BOOST_SPIRIT_X4_CHAR_CLASS(noncharacter_code_point)
 BOOST_SPIRIT_X4_CHAR_CLASS(default_ignorable_code_point)
 
 // Unicode Scripts
+
 BOOST_SPIRIT_X4_CHAR_CLASS(adlam)
 BOOST_SPIRIT_X4_CHAR_CLASS(caucasian_albanian)
 BOOST_SPIRIT_X4_CHAR_CLASS(ahom)

--- a/include/boost/spirit/x4/char/unicode_char_class.hpp
+++ b/include/boost/spirit/x4/char/unicode_char_class.hpp
@@ -556,9 +556,12 @@ struct unicode_char_class : char_parser<char_encoding::unicode, unicode_char_cla
 };
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(name) \
-    inline constexpr unicode_char_class<char_classes::unicode::name##_tag> name{};
-
-namespace unicode {
+    namespace unicode { \
+    inline constexpr unicode_char_class<char_classes::unicode::name##_tag> name{}; \
+    } /* unicode */ \
+    namespace parsers::unicode { \
+    using x4::unicode::name; \
+    } /* parsers::unicode */
 
 // Unicode Major Categories
 
@@ -801,8 +804,6 @@ BOOST_SPIRIT_X4_CHAR_CLASS(zanabazar_square)
 BOOST_SPIRIT_X4_CHAR_CLASS(inherited)
 BOOST_SPIRIT_X4_CHAR_CLASS(common)
 BOOST_SPIRIT_X4_CHAR_CLASS(unknown)
-
-} // unicode
 
 #undef BOOST_SPIRIT_X4_CHAR_CLASS
 

--- a/include/boost/spirit/x4/char/unicode_char_class.hpp
+++ b/include/boost/spirit/x4/char/unicode_char_class.hpp
@@ -16,6 +16,23 @@
 
 namespace boost::spirit::x4 {
 
+namespace char_classes::unicode {
+
+// Common Categories (semantically compatible with `standard::*` variants)
+using char_tag = char_classes::char_tag;
+using alnum_tag = char_classes::alnum_tag;
+using alpha_tag = char_classes::alpha_tag;
+using digit_tag = char_classes::digit_tag;
+using xdigit_tag = char_classes::xdigit_tag;
+using cntrl_tag = char_classes::cntrl_tag;
+using graph_tag = char_classes::graph_tag;
+using lower_tag = char_classes::lower_tag;
+using print_tag = char_classes::print_tag;
+using punct_tag = char_classes::punct_tag;
+using space_tag = char_classes::space_tag;
+using blank_tag = char_classes::blank_tag;
+using upper_tag = char_classes::upper_tag;
+
 // Unicode Major Categories
 struct letter_tag {};
 struct mark_tag {};
@@ -239,6 +256,8 @@ struct inherited_tag {};
 struct common_tag {};
 struct unknown_tag {};
 
+} // char_classes::unicode
+
 namespace detail {
 
 struct unicode_char_class_base
@@ -249,7 +268,7 @@ struct unicode_char_class_base
 #define BOOST_SPIRIT_X4_BASIC_CLASSIFY(name) \
     template<class Char> \
     static constexpr bool \
-    is(name##_tag, Char ch) noexcept \
+    is(char_classes::unicode::name##_tag, Char ch) noexcept \
     { \
         return (encoding_type::is##name)(detail::cast_char<char_type>(ch)); \
     }
@@ -257,7 +276,7 @@ struct unicode_char_class_base
 #define BOOST_SPIRIT_X4_CLASSIFY(name) \
     template<class Char> \
     static constexpr bool \
-    is(name##_tag, Char ch) noexcept \
+    is(char_classes::unicode::name##_tag, Char ch) noexcept \
     { \
         return (encoding_type::is_##name)(detail::cast_char<char_type>(ch)); \
     }
@@ -528,7 +547,7 @@ struct unicode_char_class : char_parser<char_encoding::unicode, unicode_char_cla
 };
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(name) \
-    using name##_type = unicode_char_class<name##_tag>; \
+    using name##_type = unicode_char_class<char_classes::unicode::name##_tag>; \
     inline constexpr name##_type name{};
 
 namespace unicode {

--- a/include/boost/spirit/x4/core/action.hpp
+++ b/include/boost/spirit/x4/core/action.hpp
@@ -23,9 +23,9 @@
 
 namespace boost::spirit::x4 {
 
-struct raw_attribute_type; // TODO: move this to detail
-
 namespace detail {
+
+struct raw_attribute_t;
 
 // Compose attr(where(val(pass(context))))
 template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
@@ -238,15 +238,14 @@ private:
         return false;
     }
 
-    // attr==raw_attribute_type, action wants iterator_range (see raw.hpp)
+    // attr==raw, action wants iterator_range (see raw.hpp)
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context>
     [[nodiscard]] constexpr bool
-    parse_main(
-        It& first, Se const& last, Context const& ctx, raw_attribute_type&
-    ) const noexcept(false) // construction of `subrange` is never noexcept as per the standard
+    parse_main(It& first, Se const& last, Context const& ctx, detail::raw_attribute_t&) const
+        noexcept(false) // construction of `subrange` is never noexcept as per the standard
     {
         // synthesize the attribute since one is not supplied
-        std::ranges::subrange<It, Se> rng;
+        std::ranges::subrange<It, It> rng; // This must be It-It pair, NOT It-Se pair
         return this->parse_main(first, last, ctx, rng);
     }
 };

--- a/include/boost/spirit/x4/debug/annotate_on_success.hpp
+++ b/include/boost/spirit/x4/debug/annotate_on_success.hpp
@@ -39,7 +39,7 @@ struct annotate_on_success
     // Catch-all default overload
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
     constexpr void
-    on_success(It const& first, Se const& last, Context const& ctx, Attr& ast)
+    on_success(It const& first, Se const& last, Context const& ctx, Attr& attr)
     {
         auto&& error_handler_ref = x4::get<contexts::error_handler>(ctx);
 
@@ -51,12 +51,12 @@ struct annotate_on_success
 
         // unwrap `reference_wrapper` if necessary
         if constexpr (requires {
-            error_handler_ref.get().tag(ast, first, last);
+            error_handler_ref.get().tag(attr, first, last);
         }) {
-            error_handler_ref.get().tag(ast, first, last);
+            error_handler_ref.get().tag(attr, first, last);
 
         } else {
-            error_handler_ref.tag(ast, first, last);
+            error_handler_ref.tag(attr, first, last);
         }
     }
 };

--- a/include/boost/spirit/x4/debug/error_reporting.hpp
+++ b/include/boost/spirit/x4/debug/error_reporting.hpp
@@ -52,25 +52,25 @@ public:
 
     void operator()(It err_pos, std::string const& error_message) const;
     void operator()(It err_first, It err_last, std::string const& error_message) const;
-    void operator()(position_tagged pos, std::string const& message) const
+    void operator()(ast::position_tagged const& pos, std::string const& message) const
     {
         auto where = pos_cache.position_of(pos);
         (*this)(where.begin(), where.end(), message);
     }
 
-    template<class AST>
-    void tag(AST& ast, It first, It last)
+    template<X4Attribute Attr>
+    void tag(Attr& attr, It first, It last)
     {
-        return pos_cache.annotate(ast, first, last);
+        return pos_cache.annotate(attr, first, last);
     }
 
     [[nodiscard]] std::ranges::subrange<It>
-    position_of(position_tagged pos) const
+    position_of(ast::position_tagged const& pos) const
     {
         return pos_cache.position_of(pos);
     }
 
-    [[nodiscard]] position_cache<std::vector<It>> const&
+    [[nodiscard]] ast::position_cache<std::vector<It>> const&
     get_position_cache() const noexcept
     {
         return pos_cache;
@@ -87,7 +87,7 @@ private:
     std::ostream& err_out;
     std::string file;
     int tabs;
-    position_cache<std::vector<It>> pos_cache;
+    ast::position_cache<std::vector<It>> pos_cache;
 };
 
 template<std::forward_iterator It>

--- a/include/boost/spirit/x4/directive/confix.hpp
+++ b/include/boost/spirit/x4/directive/confix.hpp
@@ -125,11 +125,13 @@ struct confix_fn
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::confix_fn confix{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::confix;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/expect.hpp
+++ b/include/boost/spirit/x4/directive/expect.hpp
@@ -66,11 +66,13 @@ struct expect_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::expect_gen expect{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::expect;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/lexeme.hpp
+++ b/include/boost/spirit/x4/directive/lexeme.hpp
@@ -87,11 +87,13 @@ struct lexeme_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::lexeme_gen lexeme{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::lexeme;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/matches.hpp
+++ b/include/boost/spirit/x4/directive/matches.hpp
@@ -70,11 +70,13 @@ struct matches_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::matches_gen matches{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::matches;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/no_case.hpp
+++ b/include/boost/spirit/x4/directive/no_case.hpp
@@ -72,11 +72,13 @@ struct no_case_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::no_case_gen no_case{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::no_case;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/no_skip.hpp
+++ b/include/boost/spirit/x4/directive/no_skip.hpp
@@ -97,11 +97,13 @@ struct no_skip_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::no_skip_gen no_skip{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::no_skip;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/omit.hpp
+++ b/include/boost/spirit/x4/directive/omit.hpp
@@ -63,11 +63,13 @@ struct omit_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 [[maybe_unused]] inline constexpr detail::omit_gen omit{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::omit;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/raw.hpp
+++ b/include/boost/spirit/x4/directive/raw.hpp
@@ -22,16 +22,20 @@
 
 namespace boost::spirit::x4 {
 
+namespace detail {
+
 // Pseudo attribute type indicating that the parser wants the
 // iterator range pointing to the [first, last) matching characters from
 // the input iterators.
-struct raw_attribute_type {}; // TODO: move this to detail
+struct raw_attribute_t {};
+
+} // detail
 
 template<class Subject>
 struct raw_directive : unary_parser<Subject, raw_directive<Subject>>
 {
     using base_type = unary_parser<Subject, raw_directive<Subject>>;
-    using attribute_type = raw_attribute_type;
+    using attribute_type = detail::raw_attribute_t;
     using subject_type = Subject;
 
     static constexpr bool handles_container = true;
@@ -96,12 +100,12 @@ inline constexpr detail::raw_gen raw{};
 namespace boost::spirit::x4::traits {
 
 template<class Context, std::forward_iterator It>
-struct pseudo_attribute<Context, raw_attribute_type, It>
+struct pseudo_attribute<Context, x4::detail::raw_attribute_t, It>
 {
-    using attribute_type = raw_attribute_type;
-    using type = std::ranges::subrange<It>;
+    using attribute_type = x4::detail::raw_attribute_t;
+    using type = std::ranges::subrange<It, It>; // This must be It-It pair, NOT It-Se pair
 
-    [[nodiscard]] static constexpr type call(It& first, std::sentinel_for<It> auto const& last, raw_attribute_type)
+    [[nodiscard]] static constexpr type call(It& first, std::sentinel_for<It> auto const& last, x4::detail::raw_attribute_t)
     {
         return {first, last};
     }

--- a/include/boost/spirit/x4/directive/raw.hpp
+++ b/include/boost/spirit/x4/directive/raw.hpp
@@ -89,11 +89,13 @@ struct raw_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::raw_gen raw{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::raw;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/repeat.hpp
+++ b/include/boost/spirit/x4/directive/repeat.hpp
@@ -182,11 +182,13 @@ struct repeat_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::repeat_gen repeat{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::repeat;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/seek.hpp
+++ b/include/boost/spirit/x4/directive/seek.hpp
@@ -72,11 +72,13 @@ struct seek_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::seek_gen seek{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::seek;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/skip.hpp
+++ b/include/boost/spirit/x4/directive/skip.hpp
@@ -184,12 +184,15 @@ struct reskip_gen
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 inline constexpr detail::skip_gen skip{};
 inline constexpr detail::reskip_gen reskip{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::skip;
+using parsers::directive::reskip;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/directive/with.hpp
+++ b/include/boost/spirit/x4/directive/with.hpp
@@ -201,14 +201,16 @@ struct with_fn
 
 } // detail
 
-inline namespace cpos {
+namespace parsers::directive {
 
 // `with` directive injects a value into the context prior to parsing.
 // Holds lvalue references by reference, holds rvalue reference by value.
 template<class ID>
 inline constexpr detail::with_fn<ID> with{};
 
-} // cpos
+} // parsers::directive
+
+using parsers::directive::with;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/numeric/bool.hpp
+++ b/include/boost/spirit/x4/numeric/bool.hpp
@@ -166,6 +166,14 @@ inline constexpr literal_bool_parser<bool, char_encoding::standard> false_{false
 
 } // standard
 
+namespace parsers::standard {
+
+using x4::standard::bool_;
+using x4::standard::true_;
+using x4::standard::false_;
+
+} // parsers::standard
+
 #ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
 namespace standard_wide {
 
@@ -174,6 +182,14 @@ inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> true_{t
 inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> false_{false};
 
 } // standard_wide
+
+namespace parsers::standard_wide {
+
+using x4::standard_wide::bool_;
+using x4::standard_wide::true_;
+using x4::standard_wide::false_;
+
+} // parsers::standard_wide
 #endif
 
 // TODO: unicode bool parser
@@ -181,6 +197,14 @@ inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> false_{
 using standard::bool_;
 using standard::true_;
 using standard::false_;
+
+namespace parsers {
+
+using x4::standard::bool_;
+using x4::standard::true_;
+using x4::standard::false_;
+
+} // parsers
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/numeric/bool.hpp
+++ b/include/boost/spirit/x4/numeric/bool.hpp
@@ -160,28 +160,18 @@ private:
 
 namespace standard {
 
-using bool_type = bool_parser<bool, char_encoding::standard>;
-inline constexpr bool_type bool_{};
-
-using true_type = literal_bool_parser<bool, char_encoding::standard>;
-inline constexpr true_type true_{true};
-
-using false_type = literal_bool_parser<bool, char_encoding::standard>;
-inline constexpr false_type false_{false};
+inline constexpr bool_parser<bool, char_encoding::standard> bool_{};
+inline constexpr literal_bool_parser<bool, char_encoding::standard> true_{true};
+inline constexpr literal_bool_parser<bool, char_encoding::standard> false_{false};
 
 } // standard
 
 #ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
 namespace standard_wide {
 
-using bool_type = bool_parser<bool, char_encoding::standard_wide>;
-inline constexpr bool_type bool_{};
-
-using true_type = literal_bool_parser<bool, char_encoding::standard_wide>;
-inline constexpr true_type true_{true};
-
-using false_type = literal_bool_parser<bool, char_encoding::standard_wide>;
-inline constexpr false_type false_{false};
+inline constexpr bool_parser<bool, char_encoding::standard_wide> bool_{};
+inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> true_{true};
+inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> false_{false};
 
 } // standard_wide
 #endif

--- a/include/boost/spirit/x4/numeric/int.hpp
+++ b/include/boost/spirit/x4/numeric/int.hpp
@@ -50,7 +50,7 @@ struct int_parser : parser<int_parser<T, Radix, MinDigits, MaxDigits>>
     }
 };
 
-inline namespace cpos {
+namespace parsers {
 
 inline constexpr int_parser<short> short_{};
 inline constexpr int_parser<int> int_{};
@@ -62,7 +62,17 @@ inline constexpr int_parser<std::int16_t> int16{};
 inline constexpr int_parser<std::int32_t> int32{};
 inline constexpr int_parser<std::int64_t> int64{};
 
-} // cpos
+} // parsers
+
+using parsers::short_;
+using parsers::int_;
+using parsers::long_;
+using parsers::long_long;
+
+using parsers::int8;
+using parsers::int16;
+using parsers::int32;
+using parsers::int64;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/numeric/int.hpp
+++ b/include/boost/spirit/x4/numeric/int.hpp
@@ -42,11 +42,11 @@ struct int_parser : parser<int_parser<T, Radix, MinDigits, MaxDigits>>
     parse(It& first, Se const& last, Context const& ctx, Attr& attr)
         noexcept(
             noexcept(x4::skip_over(first, last, ctx)) &&
-            noexcept(extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
+            noexcept(numeric::extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
         )
     {
         x4::skip_over(first, last, ctx);
-        return extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr);
+        return numeric::extract_int<T, Radix, MinDigits, MaxDigits>::call(first, last, attr);
     }
 };
 

--- a/include/boost/spirit/x4/numeric/int.hpp
+++ b/include/boost/spirit/x4/numeric/int.hpp
@@ -52,30 +52,15 @@ struct int_parser : parser<int_parser<T, Radix, MinDigits, MaxDigits>>
 
 inline namespace cpos {
 
-using short_type = int_parser<short>;
-inline constexpr short_type short_{};
+inline constexpr int_parser<short> short_{};
+inline constexpr int_parser<int> int_{};
+inline constexpr int_parser<long> long_{};
+inline constexpr int_parser<long long> long_long{};
 
-using int_type = int_parser<int>;
-inline constexpr int_type int_{};
-
-using long_type = int_parser<long>;
-inline constexpr long_type long_{};
-
-using long_long_type = int_parser<long long>;
-inline constexpr long_long_type long_long{};
-
-
-using int8_type = int_parser<std::int8_t>;
-inline constexpr int8_type int8{};
-
-using int16_type = int_parser<std::int16_t>;
-inline constexpr int16_type int16{};
-
-using int32_type = int_parser<std::int32_t>;
-inline constexpr int32_type int32{};
-
-using int64_type = int_parser<std::int64_t>;
-inline constexpr int64_type int64{};
+inline constexpr int_parser<std::int8_t> int8{};
+inline constexpr int_parser<std::int16_t> int16{};
+inline constexpr int_parser<std::int32_t> int32{};
+inline constexpr int_parser<std::int64_t> int64{};
 
 } // cpos
 

--- a/include/boost/spirit/x4/numeric/real.hpp
+++ b/include/boost/spirit/x4/numeric/real.hpp
@@ -230,13 +230,17 @@ private:
     BOOST_SPIRIT_NO_UNIQUE_ADDRESS RealPolicies policies_{};
 };
 
-inline namespace cpos {
+namespace parsers {
 
 inline constexpr real_parser<float> float_{};
 inline constexpr real_parser<double> double_{};
 inline constexpr real_parser<long double> long_double{};
 
-} // cpos
+} // parsers
+
+using parsers::float_;
+using parsers::double_;
+using parsers::long_double;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/numeric/real.hpp
+++ b/include/boost/spirit/x4/numeric/real.hpp
@@ -232,14 +232,9 @@ private:
 
 inline namespace cpos {
 
-using float_type = real_parser<float>;
-inline constexpr float_type float_{};
-
-using double_type = real_parser<double>;
-inline constexpr double_type double_{};
-
-using long_double_type = real_parser<long double>;
-inline constexpr long_double_type long_double{};
+inline constexpr real_parser<float> float_{};
+inline constexpr real_parser<double> double_{};
+inline constexpr real_parser<long double> long_double{};
 
 } // cpos
 

--- a/include/boost/spirit/x4/numeric/real.hpp
+++ b/include/boost/spirit/x4/numeric/real.hpp
@@ -47,9 +47,9 @@ struct ureal_policies
     template<std::forward_iterator It, std::sentinel_for<It> Se, X4Attribute Attr>
     [[nodiscard]] static constexpr bool
     parse_n(It& first, Se const& last, Attr& attr_)
-        noexcept(noexcept(extract_uint<T, 10, 1, -1>::call(first, last, attr_)))
+        noexcept(noexcept(numeric::extract_uint<T, 10, 1, -1>::call(first, last, attr_)))
     {
-        return extract_uint<T, 10, 1, -1>::call(first, last, attr_);
+        return numeric::extract_uint<T, 10, 1, -1>::call(first, last, attr_);
     }
 
     template<std::forward_iterator It, std::sentinel_for<It> Se>
@@ -67,9 +67,9 @@ struct ureal_policies
     template<std::forward_iterator It, std::sentinel_for<It> Se, X4Attribute Attr>
     [[nodiscard]] static constexpr bool
     parse_frac_n(It& first, Se const& last, Attr& attr_)
-        noexcept(noexcept(extract_uint<T, 10, 1, -1, true>::call(first, last, attr_)))
+        noexcept(noexcept(numeric::extract_uint<T, 10, 1, -1, true>::call(first, last, attr_)))
     {
-        return extract_uint<T, 10, 1, -1, true>::call(first, last, attr_);
+        return numeric::extract_uint<T, 10, 1, -1, true>::call(first, last, attr_);
     }
 
     template<std::forward_iterator It, std::sentinel_for<It> Se>
@@ -87,9 +87,9 @@ struct ureal_policies
     template<std::forward_iterator It, std::sentinel_for<It> Se>
     [[nodiscard]] static constexpr bool
     parse_exp_n(It& first, Se const& last, int& attr_)
-        noexcept(noexcept(extract_int<int, 10, 1, -1>::call(first, last, attr_)))
+        noexcept(noexcept(numeric::extract_int<int, 10, 1, -1>::call(first, last, attr_)))
     {
-        return extract_int<int, 10, 1, -1>::call(first, last, attr_);
+        return numeric::extract_int<int, 10, 1, -1>::call(first, last, attr_);
     }
 
     // The parse_nan() and parse_inf() functions get called whenever
@@ -159,9 +159,9 @@ struct real_policies : ureal_policies<T>
     template<std::forward_iterator It, std::sentinel_for<It> Se>
     [[nodiscard]] static constexpr bool
     parse_sign(It& first, Se const& last)
-        noexcept(noexcept(detail::extract_sign(first, last)))
+        noexcept(noexcept(numeric::detail::extract_sign(first, last)))
     {
-        return detail::extract_sign(first, last);
+        return numeric::detail::extract_sign(first, last);
     }
 };
 
@@ -201,11 +201,11 @@ struct real_parser : parser<real_parser<T, RealPolicies>>
     parse(It& first, Se const& last, Context const& ctx, T& attr_) const
         noexcept(
             noexcept(x4::skip_over(first, last, ctx)) &&
-            noexcept(extract_real<T, RealPolicies>::parse(first, last, attr_, policies_))
+            noexcept(numeric::extract_real<T, RealPolicies>::parse(first, last, attr_, policies_))
         )
     {
         x4::skip_over(first, last, ctx);
-        return extract_real<T, RealPolicies>::parse(first, last, attr_, policies_);
+        return numeric::extract_real<T, RealPolicies>::parse(first, last, attr_, policies_);
     }
 
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>

--- a/include/boost/spirit/x4/numeric/uint.hpp
+++ b/include/boost/spirit/x4/numeric/uint.hpp
@@ -51,40 +51,19 @@ struct uint_parser : parser<uint_parser<T, Radix, MinDigits, MaxDigits>>
 
 inline namespace cpos {
 
-using ushort_type = uint_parser<unsigned short>;
-inline constexpr ushort_type ushort_{};
+inline constexpr uint_parser<unsigned short> ushort_{};
+inline constexpr uint_parser<unsigned int> uint_{};
+inline constexpr uint_parser<unsigned long> ulong_{};
+inline constexpr uint_parser<unsigned long long> ulong_long{};
 
-using uint_type = uint_parser<unsigned int>;
-inline constexpr uint_type uint_{};
+inline constexpr uint_parser<std::uint8_t> uint8{};
+inline constexpr uint_parser<std::uint16_t> uint16{};
+inline constexpr uint_parser<std::uint32_t> uint32{};
+inline constexpr uint_parser<std::uint64_t> uint64{};
 
-using ulong_type = uint_parser<unsigned long>;
-inline constexpr ulong_type ulong_{};
-
-using ulong_long_type = uint_parser<unsigned long long>;
-inline constexpr ulong_long_type ulong_long{};
-
-
-using uint8_type = uint_parser<std::uint8_t>;
-inline constexpr uint8_type uint8{};
-
-using uint16_type = uint_parser<std::uint16_t>;
-inline constexpr uint16_type uint16{};
-
-using uint32_type = uint_parser<std::uint32_t>;
-inline constexpr uint32_type uint32{};
-
-using uint64_type = uint_parser<std::uint64_t>;
-inline constexpr uint64_type uint64{};
-
-
-using bin_type = uint_parser<unsigned, 2>;
-inline constexpr bin_type bin{};
-
-using oct_type = uint_parser<unsigned, 8>;
-inline constexpr oct_type oct{};
-
-using hex_type = uint_parser<unsigned, 16>;
-inline constexpr hex_type hex{};
+inline constexpr uint_parser<unsigned, 2> bin{};
+inline constexpr uint_parser<unsigned, 8> oct{};
+inline constexpr uint_parser<unsigned, 16> hex{};
 
 } // cpos
 

--- a/include/boost/spirit/x4/numeric/uint.hpp
+++ b/include/boost/spirit/x4/numeric/uint.hpp
@@ -41,11 +41,11 @@ struct uint_parser : parser<uint_parser<T, Radix, MinDigits, MaxDigits>>
     parse(It& first, Se const& last, Context const& ctx, Attr& attr)
         noexcept(
             noexcept(x4::skip_over(first, last, ctx)) &&
-            noexcept(extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
+            noexcept(numeric::extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr))
         )
     {
         x4::skip_over(first, last, ctx);
-        return extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr);
+        return numeric::extract_uint<T, Radix, MinDigits, MaxDigits>::call(first, last, attr);
     }
 };
 

--- a/include/boost/spirit/x4/numeric/uint.hpp
+++ b/include/boost/spirit/x4/numeric/uint.hpp
@@ -49,7 +49,7 @@ struct uint_parser : parser<uint_parser<T, Radix, MinDigits, MaxDigits>>
     }
 };
 
-inline namespace cpos {
+namespace parsers {
 
 inline constexpr uint_parser<unsigned short> ushort_{};
 inline constexpr uint_parser<unsigned int> uint_{};
@@ -65,7 +65,21 @@ inline constexpr uint_parser<unsigned, 2> bin{};
 inline constexpr uint_parser<unsigned, 8> oct{};
 inline constexpr uint_parser<unsigned, 16> hex{};
 
-} // cpos
+} // parsers
+
+using parsers::ushort_;
+using parsers::uint_;
+using parsers::ulong_;
+using parsers::ulong_long;
+
+using parsers::uint8;
+using parsers::uint16;
+using parsers::uint32;
+using parsers::uint64;
+
+using parsers::bin;
+using parsers::oct;
+using parsers::hex;
 
 } // boost::spirit::x4
 

--- a/include/boost/spirit/x4/numeric/utils/extract_int.hpp
+++ b/include/boost/spirit/x4/numeric/utils/extract_int.hpp
@@ -37,7 +37,7 @@
 # define BOOST_SPIRIT_X4_NUMERICS_LOOP_UNROLL 3
 #endif
 
-namespace boost::spirit::x4 {
+namespace boost::spirit::x4::numeric {
 
 namespace detail {
 
@@ -559,6 +559,6 @@ struct extract_int
     }
 };
 
-} // boost::spirit::x4
+} // boost::spirit::x4::numeric
 
 #endif

--- a/include/boost/spirit/x4/numeric/utils/extract_real.hpp
+++ b/include/boost/spirit/x4/numeric/utils/extract_real.hpp
@@ -125,7 +125,7 @@ negate(bool /*neg*/, unused_type n) noexcept
 }
 } // boost::spirit::x4::extension
 
-namespace boost::spirit::x4 {
+namespace boost::spirit::x4::numeric {
 
 template<class T, class RealPolicies>
 struct extract_real
@@ -256,6 +256,6 @@ struct extract_real
 # pragma warning(pop)
 #endif
 
-} // boost::spirit::x4
+} // boost::spirit::x4::numeric
 
 #endif

--- a/include/boost/spirit/x4/rule.hpp
+++ b/include/boost/spirit/x4/rule.hpp
@@ -505,6 +505,13 @@ struct get_info<rule<RuleID, Attr, ForceAttr>> : detail::rule_get_info {};
 template<class RuleID, X4Attribute Attr, class RHS, bool ForceAttr, bool SkipDefinitionInjection>
 struct get_info<detail::rule_definition<RuleID, RHS, Attr, ForceAttr, SkipDefinitionInjection>> : detail::rule_get_info {};
 
+
+namespace parsers {
+
+using x4::rule;
+
+} // parsers
+
 // -------------------------------------------------------------
 
 #define BOOST_SPIRIT_X4_DEPRECATED_MACRO_WARN_I(x) _Pragma(#x)

--- a/include/boost/spirit/x4/string/case_compare.hpp
+++ b/include/boost/spirit/x4/string/case_compare.hpp
@@ -9,7 +9,6 @@
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 ==============================================================================*/
 
-#include <boost/spirit/x4/core/unused.hpp>
 #include <boost/spirit/x4/core/context.hpp>
 #include <boost/spirit/x4/char/char_class_tags.hpp>
 
@@ -96,12 +95,12 @@ struct no_case_compare
         return tag;
     }
 
-    [[nodiscard]] static constexpr alpha_tag get_char_class_tag(lower_tag) noexcept
+    [[nodiscard]] static constexpr char_classes::alpha_tag get_char_class_tag(char_classes::lower_tag) noexcept
     {
         return {};
     }
 
-    [[nodiscard]] static constexpr alpha_tag get_char_class_tag(upper_tag) noexcept
+    [[nodiscard]] static constexpr char_classes::alpha_tag get_char_class_tag(char_classes::upper_tag) noexcept
     {
         return {};
     }

--- a/include/boost/spirit/x4/string/string.hpp
+++ b/include/boost/spirit/x4/string/string.hpp
@@ -170,6 +170,34 @@ using unicode::helpers::string;
 using unicode::helpers::lit;
 #endif
 
+
+namespace parsers {
+
+namespace standard {
+using x4::standard::string;
+using x4::standard::lit;
+} // standard
+
+#ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
+namespace standard_wide {
+using x4::standard_wide::string;
+using x4::standard_wide::lit;
+} // standard_wide
+#endif
+
+#ifdef BOOST_SPIRIT_X4_UNICODE
+namespace unicode {
+using x4::unicode::string;
+using x4::unicode::lit;
+} // standard_wide
+#endif
+
+using x4::string;
+using x4::lit;
+
+} // parsers
+
+
 namespace extension {
 
 template<traits::CharLike CharT, std::size_t N>

--- a/include/boost/spirit/x4/symbols.hpp
+++ b/include/boost/spirit/x4/symbols.hpp
@@ -38,7 +38,7 @@
 #include <utility>
 
 #define BOOST_SPIRIT_X4_IMPLICIT_SHARED_SYMBOLS_WARNING(old_api) \
-    "Use `shared_" old_api "` instead. `" old_api "` has had a " \
+    "Use `unique_" old_api "` instead. `" old_api "` has had a " \
     "*implicit* trait where the underlying storage is shared via " \
     "`std::shared_ptr`. This disallows `constexpr` usage in generic " \
     "scenarios where the sharing is not actually needed at all. Even " \
@@ -393,6 +393,12 @@ using standard::symbols;
 using standard::shared_symbols;
 using standard::unique_symbols;
 
+
+namespace parsers::standard {
+using x4::standard::shared_symbols;
+using x4::standard::unique_symbols;
+} // parsers::standard
+
 #ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
 namespace standard_wide {
 
@@ -407,6 +413,11 @@ template<class T = unused_type>
 using unique_symbols = unique_symbols_parser<char_encoding::standard_wide, T>;
 
 } // standard_wide
+
+namespace parsers::standard_wide {
+using x4::standard_wide::shared_symbols;
+using x4::standard_wide::unique_symbols;
+} // parsers::standard_wide
 #endif
 
 #ifdef BOOST_SPIRIT_X4_UNICODE
@@ -419,6 +430,11 @@ template<class T = unused_type>
 using unique_symbols = unique_symbols_parser<char_encoding::unicode, T>;
 
 } // unicode
+
+namespace parsers::unicode {
+using x4::unicode::shared_symbols;
+using x4::unicode::unique_symbols;
+} // parsers::unicode
 #endif
 
 } // boost::spirit::x4

--- a/test/x4/actions.cpp
+++ b/test/x4/actions.cpp
@@ -22,7 +22,7 @@ int main()
 {
     using x4::int_;
 
-    BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(x4::int_type{}[std::true_type{}]);
+    BOOST_SPIRIT_X4_ASSERT_CONSTEXPR_CTORS(x4::int_[std::true_type{}]);
 
     {
         int x = 0;

--- a/test/x4/char_class.cpp
+++ b/test/x4/char_class.cpp
@@ -178,9 +178,7 @@ int main()
     {   // test attribute extraction
         using x4::traits::attribute_of_t;
         using x4::standard::alpha;
-        using x4::standard::alpha_type;
-
-        static_assert(std::same_as<attribute_of_t<alpha_type, unused_type>, char>);
+        static_assert(std::same_as<attribute_of_t<std::remove_const_t<decltype(x4::standard::alpha)>, unused_type>, char>);
 
         int attr = 0;
         BOOST_TEST(parse("a", alpha, attr));

--- a/test/x4/extract_int.cpp
+++ b/test/x4/extract_int.cpp
@@ -102,7 +102,7 @@ void test_overflow_handling(char const* begin, char const* end, int i)
     int initial = Base - i % Base; // just a 'random' non-equal to i number
     T x { initial };
     char const* it = begin;
-    bool const r = x4::extract_int<T, Base, 1, MaxDigits>::call(it, end, x);
+    bool const r = x4::numeric::extract_int<T, Base, 1, MaxDigits>::call(it, end, x);
 
     if (T::min <= i && i <= T::max) {
         BOOST_TEST(r);
@@ -125,7 +125,7 @@ void test_unparsed_digits_are_not_consumed(char const* it, char const* end, int 
     auto len = end - it;
     int initial = Base - i % Base; // just a 'random' non-equal to i number
     T x { initial };
-    bool const r = x4::extract_int<T, Base, 1, 1>::call(it, end, x);
+    bool const r = x4::numeric::extract_int<T, Base, 1, 1>::call(it, end, x);
     BOOST_TEST(r);
 
     if (-Base < i && i < Base) {

--- a/test/x4/lexeme.cpp
+++ b/test/x4/lexeme.cpp
@@ -17,7 +17,6 @@
 int main()
 {
     using x4::standard::space;
-    using x4::standard::space_type;
     using x4::standard::digit;
     using x4::lexeme;
     using x4::rule;

--- a/test/x4/no_skip.cpp
+++ b/test/x4/no_skip.cpp
@@ -20,7 +20,6 @@
 int main()
 {
     using x4::standard::space;
-    using x4::standard::space_type;
     using x4::standard::char_;
     using x4::lexeme;
     using x4::no_skip;

--- a/test/x4/real.hpp
+++ b/test/x4/real.hpp
@@ -30,8 +30,7 @@ struct ts_real_policies : x4::ureal_policies<T>
     static bool
     parse_frac_n(It& first, Se const& last, Attr& attr)
     {
-        namespace x4 = boost::spirit::x4;
-        return x4::extract_uint<T, 10, 1, 2, true>::call(first, last, attr);
+        return x4::numeric::extract_uint<T, 10, 1, 2, true>::call(first, last, attr);
     }
 
     //  No exponent

--- a/test/x4/real.hpp
+++ b/test/x4/real.hpp
@@ -56,7 +56,6 @@ struct ts_real_policies : x4::ureal_policies<T>
     parse_n(It& first, Se const& last, Accumulator& result)
     {
         using x4::uint_parser;
-        namespace x4 = boost::spirit::x4;
 
         constexpr uint_parser<unsigned, 10, 1, 3> uint3;
         constexpr uint_parser<unsigned, 10, 3, 3> uint3_3;

--- a/test/x4/skip.cpp
+++ b/test/x4/skip.cpp
@@ -19,7 +19,6 @@
 int main()
 {
     using x4::standard::space;
-    using x4::standard::space_type;
     using x4::standard::char_;
     using x4::standard::alpha;
     using x4::lexeme;

--- a/test/x4/to_utf8.cpp
+++ b/test/x4/to_utf8.cpp
@@ -15,32 +15,32 @@
 int main()
 {
     using x4::to_utf8;
-    using namespace std::string_literals;
+    using namespace std::string_view_literals;
 
-    BOOST_TEST_CSTR_EQ("\xED\x9F\xBF", to_utf8(0xD7FFul).c_str());
-    BOOST_TEST_CSTR_EQ("\xEE\x80\x80", to_utf8(0xE000ul).c_str());
+    BOOST_TEST(to_utf8(0xD7FFul) == "\xED\x9F\xBF"sv);
+    BOOST_TEST(to_utf8(0xE000ul) == "\xEE\x80\x80"sv);
 
     if constexpr (sizeof(L"\u00FF") == 2) {
-        BOOST_TEST_CSTR_EQ("\xC3\xBF", to_utf8(L"\u00FF"[0]).c_str());
+        BOOST_TEST(to_utf8(L"\u00FF"[0]) == "\xC3\xBF"sv);
     }
 
-    BOOST_TEST_CSTR_EQ("\xC3\xBF", to_utf8(U'\u00FF').c_str());
+    BOOST_TEST(to_utf8(U'\u00FF') == "\xC3\xBF"sv);
 
     if constexpr (sizeof(L"\uFFE1") == 2) {
-        BOOST_TEST_CSTR_EQ("\xEF\xBF\xA1", to_utf8(L"\uFFE1"[0]).c_str());
+        BOOST_TEST(to_utf8(L"\uFFE1"[0]) == "\xEF\xBF\xA1"sv);
     }
 
-    BOOST_TEST_CSTR_EQ("\xEF\xBF\xA1", to_utf8(U'\uFFE1').c_str());
+    BOOST_TEST(to_utf8(U'\uFFE1') == "\xEF\xBF\xA1"sv);
 
     if constexpr(sizeof(L"\U0001F9D0") == 2) {
-        BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90", to_utf8(L"\U0001F9D0"[0]).c_str());
+        BOOST_TEST(to_utf8(L"\U0001F9D0"[0]) == "\xF0\x9F\xA7\x90"sv);
     }
 
-    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90", to_utf8(U'\U0001F9D0').c_str());
-    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0", to_utf8(L"\U0001F9D0\U0001F9E0").c_str());
-    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0", to_utf8(U"\U0001F9D0\U0001F9E0").c_str());
-    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0", to_utf8(L"\U0001F9D0\U0001F9E0"s).c_str());
-    BOOST_TEST_CSTR_EQ("\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0", to_utf8(U"\U0001F9D0\U0001F9E0"s).c_str());
+    BOOST_TEST(to_utf8(U'\U0001F9D0') == "\xF0\x9F\xA7\x90"sv);
+    BOOST_TEST(to_utf8(L"\U0001F9D0\U0001F9E0") == "\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0"sv);
+    BOOST_TEST(to_utf8(U"\U0001F9D0\U0001F9E0") == "\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0"sv);
+    BOOST_TEST(to_utf8(L"\U0001F9D0\U0001F9E0"sv) == "\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0"sv);
+    BOOST_TEST(to_utf8(U"\U0001F9D0\U0001F9E0"sv) == "\xF0\x9F\xA7\x90\xF0\x9F\xA7\xA0"sv);
 
     return boost::report_errors();
 }


### PR DESCRIPTION
Part of #1 

Currently, X4 has enormous amount of identifiers in the `x4::` namespace, which makes the IDE completion useless. I consider this a huge barrier for both the end users and X4 developers.

<img width="219" height="236" alt="image" src="https://github.com/user-attachments/assets/be5a8e34-3f14-42e2-b762-0a477c5f2a7b" />

## Changes

- Move char_class related tags to `char_classes::`
  - These *could* be public-facing API, but in practice nobody (except for X4 devs) should be using it anyway, since the main facility of parser combinator is the actual objects, not the _tag type_ used for defining the objects.
- The `***_type` typedefs for CPOs
  - e.g. `x4::cpos::int_` is defined as `inline constexpr int_type int_{}`, where `int_type` is polluting the top-level namespace, and having no use cases in application layer
- New `x4::parsers::*` helper namespace added. Can be used essentially as the _index_ namespace for beginners.
  - `x4::parsers::directive` contains all directives.
  - `x4::parsers::standard`, `x4::parsers::standard_wide`, `x4::parsers::unicode` contains all relevant stuff. Note that this omits some utility stuff for simplicity.
  - `x4::parsers` contains everything else, but limited to parser combinator related stuff.
