### PR TITLE
Suppress unused variable warning on CPOs

### DIFF
--- a/include/boost/spirit/x4/char/char_class.hpp
+++ b/include/boost/spirit/x4/char/char_class.hpp
@@ -88,7 +88,7 @@ struct char_class_parser : char_parser<Encoding, char_class_parser<Encoding, Tag
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(encoding, name) \
     namespace encoding { \
-    inline constexpr char_class_parser<char_encoding::encoding, char_classes::name##_tag> name{}; \
+    [[maybe_unused]] inline constexpr char_class_parser<char_encoding::encoding, char_classes::name##_tag> name{}; \
     } /* encoding */ \
     namespace parsers::encoding { \
     using x4::encoding::name; \

--- a/include/boost/spirit/x4/char/unicode_char_class.hpp
+++ b/include/boost/spirit/x4/char/unicode_char_class.hpp
@@ -557,7 +557,7 @@ struct unicode_char_class : char_parser<char_encoding::unicode, unicode_char_cla
 
 #define BOOST_SPIRIT_X4_CHAR_CLASS(name) \
     namespace unicode { \
-    inline constexpr unicode_char_class<char_classes::unicode::name##_tag> name{}; \
+    [[maybe_unused]] inline constexpr unicode_char_class<char_classes::unicode::name##_tag> name{}; \
     } /* unicode */ \
     namespace parsers::unicode { \
     using x4::unicode::name; \


### PR DESCRIPTION
Part of #1 
Follow-up for #44 

https://github.com/boostorg/spirit_x4/actions/runs/17949417011/job/51044255176?pr=46#step:14:147

I think it's GCC's regression