### PR TITLE
Prevent side effect on the failed branch of `alternative`

### DIFF
--- a/include/boost/spirit/x4/operator/alternative.hpp
+++ b/include/boost/spirit/x4/operator/alternative.hpp
@@ -12,12 +12,15 @@
 
 #include <boost/spirit/x4/core/expectation.hpp>
 #include <boost/spirit/x4/core/parser.hpp>
+#include <boost/spirit/x4/core/move_to.hpp>
 #include <boost/spirit/x4/core/detail/parse_alternative.hpp>
 
 #include <boost/spirit/x4/traits/attribute.hpp>
+#include <boost/spirit/x4/traits/container_traits.hpp>
 
 #include <boost/variant/variant.hpp> // TODO: remove this
 
+#include <concepts>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -49,17 +52,109 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
                 && this->right.parse(first, last, ctx, unused));
     }
 
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
+    // If you're changing these semantics, you should:
+    //   - Understand https://github.com/boostorg/spirit/issues/378
+    //   - Add test to `attribute.cpp`. This is mandatory.
+
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, class Attr>
+        requires (!traits::X4Container<Attr>)
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
         noexcept(
             noexcept(detail::parse_alternative(this->left, first, last, ctx, attr)) &&
-            noexcept(detail::parse_alternative(this->right, first, last, ctx, attr))
+            noexcept(detail::parse_alternative(this->right, first, last, ctx, attr)) &&
+            noexcept(x4::move_to(std::declval<Attr>(), attr)) &&
+            std::is_nothrow_default_constructible_v<Attr>
         )
     {
-        return detail::parse_alternative(this->left, first, last, ctx, attr)
-            || (!x4::has_expectation_failure(ctx)
-                && detail::parse_alternative(this->right, first, last, ctx, attr));
+        static_assert(!std::same_as<std::remove_const_t<Attr>, unused_type>);
+        static_assert(!std::same_as<std::remove_const_t<Attr>, unused_container_type>);
+
+        if (Attr attr_temp; detail::parse_alternative(this->left, first, last, ctx, attr_temp)) {
+            x4::move_to(std::move(attr_temp), attr);
+            return true;
+        }
+        if (x4::has_expectation_failure(ctx)) return false;
+
+        if (Attr attr_temp; detail::parse_alternative(this->right, first, last, ctx, attr_temp)) {
+            x4::move_to(std::move(attr_temp), attr);
+            return true;
+        }
+        return false; // `attr` is untouched
+    }
+
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, traits::X4Container ContainerAttr>
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, ContainerAttr& attr) const
+        noexcept(
+            noexcept(detail::parse_alternative(this->left, first, last, ctx, attr)) &&
+            noexcept(detail::parse_alternative(this->right, first, last, ctx, attr)) &&
+            noexcept(x4::move_to(std::declval<ContainerAttr>(), attr)) &&
+            std::is_nothrow_default_constructible_v<ContainerAttr> &&
+            noexcept(traits::clear(attr))
+        )
+    {
+        static_assert(!std::same_as<std::remove_const_t<ContainerAttr>, unused_type>);
+        static_assert(!std::same_as<std::remove_const_t<ContainerAttr>, unused_container_type>);
+
+        // We can (ab)use the exposed attribute as the temporary workspace
+        // if and only if the modification or rollback of the exposed attribute
+        // does not change the semantic state of the exposed container instance.
+        //
+        // The only situation we can guarantee such condition is when the container
+        // is empty; assuming that the "empty" state of any user-provided container
+        // class is monostate.
+        if (traits::is_empty(attr)) {
+            if (detail::parse_alternative(this->left, first, last, ctx, attr)) {
+                return true;
+            }
+            traits::clear(attr); // Make sure we don't propagate observable side effect
+            if (x4::has_expectation_failure(ctx)) return false;
+
+            if (detail::parse_alternative(this->right, first, last, ctx, attr)) {
+                return true;
+            }
+            traits::clear(attr); // Make sure we don't propagate observable side effect
+            return false;
+        }
+
+        //
+        // Non-empty container
+        // Since the attribute is a container, we can reuse the buffer when the `left` fails
+        //
+        if consteval {
+            ContainerAttr attr_temp;
+
+            if (detail::parse_alternative(this->left, first, last, ctx, attr_temp)) {
+                x4::move_to(std::move(attr_temp), attr);
+                return true;
+            }
+            if (x4::has_expectation_failure(ctx)) return false;
+            traits::clear(attr_temp); // Reuse the buffer
+
+            if (detail::parse_alternative(this->right, first, last, ctx, attr_temp)) {
+                x4::move_to(std::move(attr_temp), attr);
+                return true;
+            }
+            return false; // `attr` is untouched
+
+        } else { // not consteval
+            thread_local ContainerAttr attr_temp;
+            traits::clear(attr_temp);
+
+            if (detail::parse_alternative(this->left, first, last, ctx, attr_temp)) {
+                x4::move_to(std::move(attr_temp), attr);
+                return true;
+            }
+            if (x4::has_expectation_failure(ctx)) return false;
+            traits::clear(attr_temp); // Reuse the buffer
+
+            if (detail::parse_alternative(this->right, first, last, ctx, attr_temp)) {
+                x4::move_to(std::move(attr_temp), attr);
+                return true;
+            }
+            return false; // `attr` is untouched
+        }
     }
 };
 

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -53,6 +53,7 @@ x4_define_tests(
     alternative
     and_predicate
     attr
+    attribute
     attribute_type_check
     binary
     bool

--- a/test/x4/Jamfile
+++ b/test/x4/Jamfile
@@ -62,6 +62,7 @@ obj catch2 : catch_amalgamated.cpp ;
 
 run parser.cpp catch2 ;
 run context.cpp catch2 ;
+run attribute.cpp catch2 ;
 run x3_rule_problem.cpp catch2 ;
 
 run actions.cpp catch2 ;

--- a/test/x4/attribute.cpp
+++ b/test/x4/attribute.cpp
@@ -1,0 +1,235 @@
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "test.hpp"
+
+#include <boost/spirit/x4/auxiliary/attr.hpp>
+#include <boost/spirit/x4/auxiliary/eps.hpp>
+#include <boost/spirit/x4/char/char.hpp>
+#include <boost/spirit/x4/char/char_class.hpp>
+#include <boost/spirit/x4/string/string.hpp>
+#include <boost/spirit/x4/numeric/int.hpp>
+#include <boost/spirit/x4/directive/omit.hpp>
+#include <boost/spirit/x4/operator/sequence.hpp>
+#include <boost/spirit/x4/operator/alternative.hpp>
+
+#include <boost/fusion/adapted/std_pair.hpp>
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include <utility>
+
+// NOLINTBEGIN(readability-container-size-empty)
+
+namespace {
+
+struct strong_int
+{
+    int value = 0;
+    int assigned_count = 0;
+
+    strong_int() = default;
+    strong_int(strong_int const&) = default;
+    strong_int(strong_int&&) noexcept = default;
+
+    explicit strong_int(int value) : value(value) {}
+
+    strong_int& operator=(strong_int const& other)
+    {
+        value = other.value;
+        ++assigned_count;
+        return *this;
+    }
+
+    strong_int& operator=(strong_int&& other) noexcept
+    {
+        value = other.value;
+        ++assigned_count;
+        return *this;
+    }
+
+    strong_int& operator=(int new_value)
+    {
+        value = new_value;
+        ++assigned_count;
+        return *this;
+    }
+
+    bool operator==(strong_int const& other) const
+    {
+        return value == other.value;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, strong_int const& si)
+    {
+        return os << si.value;
+    }
+};
+
+} // anonymous
+
+TEST_CASE("attribute_alternative_hold")
+{
+    using x4::attr;
+    using x4::eps;
+    using x4::omit;
+    using x4::int_;
+
+    using x4::string;
+    using x4::lit;
+    using x4::standard::char_;
+    using x4::standard::space;
+
+    // Sanity checks
+    {
+        int i = -1;
+        REQUIRE(parse("", attr(42), i));
+        CHECK(i == 42);
+    }
+    {
+        std::string str;
+        REQUIRE(parse("", attr("foo"), str));
+        CHECK(str == "foo");
+    }
+    {
+        std::string str;
+        REQUIRE(parse("foo", string("foo"), str));
+        CHECK(str == "foo");
+    }
+
+    // Non-string container attribute
+    // Related to: https://github.com/boostorg/spirit/issues/378
+    {
+        static_assert(x4::traits::CategorizedAttr<std::vector<int>, x4::traits::container_attr>);
+        static_assert(x4::traits::X4Container<std::vector<int>>);
+        static_assert(x4::traits::is_container_v<std::vector<int>>);
+
+        {
+            std::vector<int> ints;
+            REQUIRE(parse("1 2", eps(false) | attr(98) >> attr(99), ints).is_partial_match());
+            CHECK(ints == std::vector<int>{98, 99});
+        }
+        {
+            std::vector<int> ints;
+            REQUIRE(parse("1 2", int_ >> int_ >> eps(false) | attr(98) >> attr(99), space, ints).is_partial_match());
+            // If we don't properly "hold" the value on the failed branch of
+            // `x4::alternative`, we would see {1, 2, 98, 99} here.
+            CHECK(ints == std::vector<int>{98, 99});
+        }
+        // Failed parse should not modify the exposed attribute
+        {
+            std::vector<int> ints;
+            REQUIRE(!parse("1 2", int_ >> int_ >> eps(false) | attr(98) >> attr(99) >> eps(false), space, ints));
+            // Wrong implementation yields {1, 2, 98, 99} or {98, 99}
+            CHECK(ints == std::vector<int>{});
+        }
+        {
+            std::vector<int> ints;
+            REQUIRE(parse("1 2", attr(std::vector<int>{3, 4}) >> eps(false) | attr(98) >> attr(99), space, ints).is_partial_match());
+            // Wrong implementation yields {3, 4, 98, 99}
+            CHECK(ints == std::vector<int>{98, 99});
+        }
+    }
+
+    // String container attribute
+    // Intended for testing `detail::string_parse`
+    {
+        static_assert(x4::traits::CategorizedAttr<std::string, x4::traits::container_attr>);
+        static_assert(x4::traits::X4Container<std::string>);
+        static_assert(x4::traits::is_container_v<std::string>);
+
+        {
+            std::string str;
+            REQUIRE(parse("foodie", "fox" | string("foodie"), str));
+            CHECK(str == "foodie");
+        }
+        {
+            constexpr auto fox = char_('f') >> char_('o') >> char_('x');
+
+            std::string str;
+            REQUIRE(parse("foodie", fox | string("foodie"), str));
+            // If we don't properly "hold" the value on the failed branch of
+            // `x4::alternative`, we would see "fofoodie" here.
+            CHECK(str == "foodie");
+        }
+        {
+            constexpr auto foo = char_('f') >> char_('o') >> char_('o');
+
+            std::string str;
+            REQUIRE(parse("foodie", foo >> eps(false) | string("foodie"), str));
+            // Wrong implementation yields "foofoodie"
+            CHECK(str == "foodie");
+        }
+        {
+            std::string str;
+            REQUIRE(parse("foodie", attr("bookworm") >> eps(false) | string("foodie"), str));
+            // Wrong implementation yields "bookwormfoodie"
+            CHECK(str == "foodie");
+        }
+        // Failed parse should not modify the exposed attribute
+        {
+            std::string str;
+            REQUIRE(!parse("foodie", attr("bookworm") >> eps(false) | string("foodie") >> eps(false), str));
+            // Wrong implementation yields "bookwormfoodie" or "foodie"
+            CHECK(str == "");
+        }
+
+        {
+            std::string str;
+            REQUIRE(parse("foodie", string("food") >> "fan" | string("foodie"), str));
+            // Wrong implementation yields "foodfoodie"
+            CHECK(str == "foodie");
+        }
+    }
+
+    // Plain attribute
+    {
+        static_assert(x4::traits::CategorizedAttr<strong_int, x4::traits::plain_attr>);
+        static_assert(!x4::traits::X4Container<strong_int>);
+        static_assert(!x4::traits::is_container_v<strong_int>);
+
+        {
+            strong_int si;
+            REQUIRE(parse("1", int_ | attr(strong_int{9}), si));
+            CHECK(si == strong_int{1});
+            CHECK(si.assigned_count == 1);
+        }
+        {
+            strong_int si;
+            REQUIRE(parse("1", int_ >> eps(false) | int_, si));
+            CHECK(si == strong_int{1});
+            // Wrong implementation yields 2, because `x4::alternative` wrongly mutates the exposed variable
+            CHECK(si.assigned_count == 1);
+        }
+    }
+
+    // Tuple attribute
+    {
+        using pair_int = std::pair<int, int>;
+
+        static_assert(x4::traits::CategorizedAttr<pair_int, x4::traits::tuple_attr>);
+        static_assert(!x4::traits::X4Container<pair_int>);
+        static_assert(!x4::traits::is_container_v<pair_int>);
+
+        {
+            pair_int pi;
+            REQUIRE(parse("1 2", int_ >> int_ | attr(pair_int{98, 99}), space, pi));
+            CHECK(pi == pair_int{1, 2});
+        }
+        {
+            pair_int pi;
+            REQUIRE(parse("1 2",
+                int_ >> int_ >> eps(false) | attr(pair_int{98, 99}) >> omit[int_ >> int_],
+                space, pi
+            ));
+            CHECK(pi == pair_int{98, 99});
+        }
+    }
+}
+
+// NOLINTEND(readability-container-size-empty)

--- a/test/x4/sequence.cpp
+++ b/test/x4/sequence.cpp
@@ -471,6 +471,9 @@ TEST_CASE("sequence")
                 std::declval<decltype(std::make_move_iterator(traits::end(c)))>()
             );
         });
+        STATIC_CHECK(requires(T& c) {
+            traits::clear(c);
+        });
 
         STATIC_CHECK(traits::is_container_v<std::vector<spirit_test::move_only>>);
         STATIC_CHECK(traits::CategorizedAttr<std::vector<spirit_test::move_only>, x4::traits::container_attr>);


### PR DESCRIPTION
Part of boostorg/spirit_x4#1 
Fixes boostorg/spirit#835 

This PR fixes boostorg/spirit#835, which still exists in X4.

Before the fix, the example below yields `"foodfoodie"`, where the expected outcome is `"foodie"`. In my opinion this is a very bad behavior that exposes surprising side effects to the end users.

```cpp
std::string str;
x4::parse("foodie", x4::string("food") >> "fan" | x4::string("foodie"), str);
```

This PR takes the hybrid approach of number 2 and 5 described in boostorg/spirit#835.

There was also some interesting idea https://github.com/boostorg/spirit/issues/835 that suggests preserving the old container size and rolling back to the saved size after the failed alternative branch. However, I consider it as too unstable, given the fact that it would result in another surprising side effect.

User-provided container class can have arbitrary semantics on the partial insertion and removal of the elements. Even if we roll back the appended contents, there's no guarantee that the container class is _equal_ in the domain of that class. For example, `std::vector` would reallocate and move the existing contents when the capacity is insufficient. That is an observable side effect from the user's perspective. IMHO, Spirit simply shouldn't do such dangerous thing in implementation details.

That said, there exists future opportunity where we can implement the suggestion noted above. That requires at least the new trait to assure the user-provided container class guarantees no side effects on the insertion/removal of the elements. This PR aims to resolve the issue in the first place, and further work is considered as future optimization.