### PR TITLE
Relax expectation failure context requirement

### DIFF
--- a/include/boost/spirit/x4/core/expectation.hpp
+++ b/include/boost/spirit/x4/core/expectation.hpp
@@ -110,9 +110,8 @@ template<class Context>
 [[nodiscard]]
 constexpr bool has_expectation_failure(Context const& ctx) noexcept
 {
-    using T = expectation_failure_t<Context>;
     static_assert(
-        !std::same_as<unused_type, T>,
+        has_context_v<Context, contexts::expectation_failure>,
         "Context type was not specified for `x4::contexts::expectation_failure`. "
         "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
@@ -132,9 +131,8 @@ constexpr void set_expectation_failure(
 )
     noexcept(noexcept(x4::get<contexts::expectation_failure>(ctx).emplace(std::move(where), x4::what(subject))))
 {
-    using T = expectation_failure_t<Context>;
     static_assert(
-        !std::same_as<unused_type, T>,
+        has_context_v<Context, contexts::expectation_failure>,
         "Context type was not specified for `x4::contexts::expectation_failure`. "
         "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
@@ -146,9 +144,8 @@ template<class Context>
 [[nodiscard]]
 constexpr decltype(auto) get_expectation_failure(Context const& ctx) noexcept
 {
-    using T = expectation_failure_t<Context>;
     static_assert(
-        !std::same_as<T, unused_type>,
+        has_context_v<Context, contexts::expectation_failure>,
         "Context type was not specified for `x4::contexts::expectation_failure`. "
         "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."
@@ -160,9 +157,8 @@ constexpr decltype(auto) get_expectation_failure(Context const& ctx) noexcept
 template<class Context>
 constexpr void clear_expectation_failure(Context const& ctx) noexcept
 {
-    using T = expectation_failure_t<Context>;
     static_assert(
-        !std::same_as<T, unused_type>,
+        has_context_v<Context, contexts::expectation_failure>,
         "Context type was not specified for `x4::contexts::expectation_failure`. "
         "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
         "Note that you must also bind the context to your skipper."

--- a/include/boost/spirit/x4/core/skip_over.hpp
+++ b/include/boost/spirit/x4/core/skip_over.hpp
@@ -108,7 +108,7 @@ template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Su
 constexpr void skip_over(It& first, Se const& last, Context const& ctx, Skipper const& skipper)
     noexcept(is_nothrow_parsable_v<Skipper, It, Se, typename skip_over_context<Context>::type, unused_type>)
 {
-    if constexpr (std::is_same_v<expectation_failure_t<Context>, unused_type>) {
+    if constexpr (!has_context_v<Context, contexts::expectation_failure>) {
         // The context given by parent was truly `unused_type`.
         // There exists only one such case in core; that is
         // `x4::phrase_parse(...)` which creates a fresh context
@@ -143,7 +143,7 @@ constexpr void skip_over(It& first, Se const& last, Context const& ctx, Skipper 
         //
         // Since the reference bound to `x4::contexts::expectation_failure` is
         // provided by the user in the first place, if we do forget it
-        // then it will be impossible to resurrect the value afterwards.
+        // then it will be impossible to resurrect the value afterward.
         // It will also be problematic for `skip_over` itself because the
         // underlying skipper may (or may not) raise an expectation failure.
         // In traditional mode, the error was thrown by a C++ exception.

--- a/include/boost/spirit/x4/directive/confix.hpp
+++ b/include/boost/spirit/x4/directive/confix.hpp
@@ -63,9 +63,11 @@ struct confix_directive
               this->subject.parse(first, last, ctx, attr) &&
               postfix_.parse(first, last, ctx, unused))
         ) {
-            if (x4::has_expectation_failure(ctx)) {
-                // don't rollback iterator (mimicking exception-like behavior)
-                return false;
+            if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+                if (x4::has_expectation_failure(ctx)) {
+                    // don't rollback iterator (mimicking exception-like behavior)
+                    return false;
+                }
             }
 
             first = saved_first;

--- a/include/boost/spirit/x4/directive/expect.hpp
+++ b/include/boost/spirit/x4/directive/expect.hpp
@@ -41,6 +41,13 @@ struct expect_directive : unary_parser<Subject, expect_directive<Subject>>
     parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
         // never noexcept; expectation failure requires construction of debug information
     {
+        static_assert(
+            has_context_v<Context, contexts::expectation_failure>,
+            "Context type was not specified for `x4::contexts::expectation_failure`. "
+            "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
+            "Note that you must also bind the context to your skipper."
+        );
+
         bool const r = this->subject.parse(first, last, ctx, attr);
 
         // only the first failure is needed
@@ -89,6 +96,13 @@ struct parse_into_container_impl<expect_directive<Subject>, Context>
         It& first, Se const& last, Context const& ctx, Attr& attr
     ) // never noexcept; expectation failure requires construction of debug information
     {
+        static_assert(
+            has_context_v<Context, contexts::expectation_failure>,
+            "Context type was not specified for `x4::contexts::expectation_failure`. "
+            "You probably forgot: `x4::with<x4::contexts::expectation_failure>(failure)[p]`. "
+            "Note that you must also bind the context to your skipper."
+        );
+
         bool const r = detail::parse_into_container(parser.subject, first, last, ctx, attr);
 
         // only the first error is needed

--- a/include/boost/spirit/x4/directive/matches.hpp
+++ b/include/boost/spirit/x4/directive/matches.hpp
@@ -48,7 +48,10 @@ struct matches_directive : unary_parser<Subject, matches_directive<Subject>>
         )
     {
         bool const matched = this->subject.parse(first, last, ctx, unused);
-        if (x4::has_expectation_failure(ctx)) return false;
+
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            if (x4::has_expectation_failure(ctx)) return false;
+        }
 
         x4::move_to(matched, attr);
         return true;

--- a/include/boost/spirit/x4/directive/repeat.hpp
+++ b/include/boost/spirit/x4/directive/repeat.hpp
@@ -118,7 +118,11 @@ struct repeat_directive : unary_parser<Subject, repeat_directive<Subject, Bounds
             }
         }
 
-        return !x4::has_expectation_failure(ctx);
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 
 private:

--- a/include/boost/spirit/x4/directive/seek.hpp
+++ b/include/boost/spirit/x4/directive/seek.hpp
@@ -47,8 +47,10 @@ struct seek_directive : unary_parser<Subject, seek_directive<Subject>>
                 return true;
             }
 
-            if (x4::has_expectation_failure(ctx)) {
-                return false;
+            if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+                if (x4::has_expectation_failure(ctx)) {
+                    return false;
+                }
             }
 
             // fail only after subject fails & no input

--- a/include/boost/spirit/x4/operator/alternative.hpp
+++ b/include/boost/spirit/x4/operator/alternative.hpp
@@ -47,9 +47,13 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
             is_nothrow_parsable_v<Right, It, Se, Context, unused_type>
         )
     {
-        return this->left.parse(first, last, ctx, unused)
-            || (!x4::has_expectation_failure(ctx)
-                && this->right.parse(first, last, ctx, unused));
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return this->left.parse(first, last, ctx, unused) ||
+                (!x4::has_expectation_failure(ctx) && this->right.parse(first, last, ctx, unused));
+        } else {
+            return this->left.parse(first, last, ctx, unused) ||
+                this->right.parse(first, last, ctx, unused);
+        }
     }
 
     // If you're changing these semantics, you should:
@@ -74,7 +78,9 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
             x4::move_to(std::move(attr_temp), attr);
             return true;
         }
-        if (x4::has_expectation_failure(ctx)) return false;
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            if (x4::has_expectation_failure(ctx)) return false;
+        }
 
         if (Attr attr_temp; detail::parse_alternative(this->right, first, last, ctx, attr_temp)) {
             x4::move_to(std::move(attr_temp), attr);
@@ -109,7 +115,10 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
                 return true;
             }
             traits::clear(attr); // Make sure we don't propagate observable side effect
-            if (x4::has_expectation_failure(ctx)) return false;
+
+            if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+                if (x4::has_expectation_failure(ctx)) return false;
+            }
 
             if (detail::parse_alternative(this->right, first, last, ctx, attr)) {
                 return true;
@@ -129,7 +138,10 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
                 x4::move_to(std::move(attr_temp), attr);
                 return true;
             }
-            if (x4::has_expectation_failure(ctx)) return false;
+
+            if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+                if (x4::has_expectation_failure(ctx)) return false;
+            }
             traits::clear(attr_temp); // Reuse the buffer
 
             if (detail::parse_alternative(this->right, first, last, ctx, attr_temp)) {
@@ -146,7 +158,10 @@ struct alternative : binary_parser<Left, Right, alternative<Left, Right>>
                 x4::move_to(std::move(attr_temp), attr);
                 return true;
             }
-            if (x4::has_expectation_failure(ctx)) return false;
+
+            if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+                if (x4::has_expectation_failure(ctx)) return false;
+            }
             traits::clear(attr_temp); // Reuse the buffer
 
             if (detail::parse_alternative(this->right, first, last, ctx, attr_temp)) {

--- a/include/boost/spirit/x4/operator/difference.hpp
+++ b/include/boost/spirit/x4/operator/difference.hpp
@@ -47,14 +47,16 @@ struct difference : binary_parser<Left, Right, difference<Left, Right>>
             return false;
         }
 
-        // In case of `Left - expect[r]`,
-        // if Right yielded expectation error,
-        // the whole difference expression (*this) should also yield error.
-        // In other words, when the THROW macro was 1 (i.e. traditional behavior),
-        // Right should already have thrown an exception.
-        if (x4::has_expectation_failure(ctx)) {
-            // don't rollback iterator (mimicking exception-like behavior)
-            return false;
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            // In case of `Left - expect[r]`,
+            // if Right yielded expectation error,
+            // the whole difference expression (*this) should also yield error.
+            // In other words, when the THROW macro was 1 (i.e. traditional behavior),
+            // Right should already have thrown an exception.
+            if (x4::has_expectation_failure(ctx)) {
+                // don't rollback iterator (mimicking exception-like behavior)
+                return false;
+            }
         }
 
         // Right fails, now try Left

--- a/include/boost/spirit/x4/operator/kleene.hpp
+++ b/include/boost/spirit/x4/operator/kleene.hpp
@@ -48,7 +48,11 @@ struct kleene : unary_parser<Subject, kleene<Subject>>
         while (detail::parse_into_container(this->subject, first, last, ctx, x4::assume_container(attr)))
             /* loop */;
 
-        return !x4::has_expectation_failure(ctx);
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 };
 

--- a/include/boost/spirit/x4/operator/list.hpp
+++ b/include/boost/spirit/x4/operator/list.hpp
@@ -62,7 +62,11 @@ struct list : binary_parser<Left, Right, list<Left, Right>>
             first = last_parse_it;
         }
 
-        return !x4::has_expectation_failure(ctx);
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 };
 

--- a/include/boost/spirit/x4/operator/not_predicate.hpp
+++ b/include/boost/spirit/x4/operator/not_predicate.hpp
@@ -45,8 +45,13 @@ struct not_predicate : unary_parser<Subject, not_predicate<Subject>>
         )
     {
         It local_first = first;
-        return !this->subject.parse(local_first, last, ctx, unused)
-            && !x4::has_expectation_failure(ctx);
+
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !this->subject.parse(local_first, last, ctx, unused) &&
+                !x4::has_expectation_failure(ctx);
+        } else {
+            return !this->subject.parse(local_first, last, ctx, unused);
+        }
     }
 };
 

--- a/include/boost/spirit/x4/operator/optional.hpp
+++ b/include/boost/spirit/x4/operator/optional.hpp
@@ -55,7 +55,12 @@ struct optional : unary_parser<Subject, optional<Subject>>
 
         // discard [[nodiscard]]
         (void)this->subject.parse(first, last, ctx, attr);
-        return !x4::has_expectation_failure(ctx);
+
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 
     // container attribute
@@ -69,7 +74,12 @@ struct optional : unary_parser<Subject, optional<Subject>>
     {
         // discard [[nodiscard]]
         (void)detail::parse_into_container(this->subject, first, last, ctx, attr);
-        return !x4::has_expectation_failure(ctx);
+
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 
     // optional attribute
@@ -95,7 +105,11 @@ struct optional : unary_parser<Subject, optional<Subject>>
             return true;
         }
 
-        return !x4::has_expectation_failure(ctx);
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 };
 

--- a/include/boost/spirit/x4/operator/plus.hpp
+++ b/include/boost/spirit/x4/operator/plus.hpp
@@ -53,7 +53,11 @@ struct plus : unary_parser<Subject, plus<Subject>>
         while (detail::parse_into_container(this->subject, first, last, ctx, x4::assume_container(attr)))
             /* loop */;
 
-        return !x4::has_expectation_failure(ctx);
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            return !x4::has_expectation_failure(ctx);
+        } else {
+            return true;
+        }
     }
 };
 

--- a/include/boost/spirit/x4/operator/sequence.hpp
+++ b/include/boost/spirit/x4/operator/sequence.hpp
@@ -56,9 +56,11 @@ struct sequence : binary_parser<Left, Right, sequence<Left, Right>>
             return true;
         }
 
-        if (x4::has_expectation_failure(ctx)) {
-            // don't rollback iterator (mimicking exception-like behavior)
-            return false;
+        if constexpr (has_context_v<Context, contexts::expectation_failure>) {
+            if (x4::has_expectation_failure(ctx)) {
+                // don't rollback iterator (mimicking exception-like behavior)
+                return false;
+            }
         }
 
         first = first_saved;


### PR DESCRIPTION
Part of #1 

The old implementation eagerly required expectation failure context regardless of whether the underlying parser has `expect[...]` directive. This change relaxes the requirement to touch the context only when such condition is met.

For end users, there's practically no use case for this feature, since the entry point `x4::parse(...)` already assigns the context by default. The only case this relaxation becomes useful is when we call `.parse(...)` directly, which is a common use case in our unit tests. This use case was found during the implementation of `x4::as<T>(...)`.