### PR TITLE
Implement `as<T>(...)` directive

### DIFF
--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -23,7 +23,19 @@ struct parse_pass
 };
 
 // _val
+// Refers to the attribute of `x4::rule`.
+// This always points to the *innermost* attribute for the (potentially recursive) invocation of `x4::rule`.
+// Note: we currently provide no method to obtain the outer attribute, as it is discouraged for maintainability.
+//
+// This does NOT point to the attribute variable created by `x4::as<T>(...)`.
 struct rule_val
+{
+    static constexpr bool is_unique = true;
+};
+
+// _as_val
+// Refers to the attribute of `x4::as<T>(...)`.
+struct as_val
 {
     static constexpr bool is_unique = true;
 };
@@ -76,6 +88,19 @@ struct _val_fn
     static void operator()(Context const&&) = delete; // dangling
 };
 
+struct _as_val_fn
+{
+    template<class Context>
+    [[nodiscard]] static constexpr auto&&
+    operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
+    {
+        return x4::get<contexts::as_val>(ctx);
+    }
+
+    template<class Context>
+    static void operator()(Context const&&) = delete; // dangling
+};
+
 struct _where_fn
 {
     template<class Context>
@@ -108,6 +133,7 @@ inline namespace cpos {
 
 inline constexpr detail::_pass_fn _pass{};
 inline constexpr detail::_val_fn _val{};
+inline constexpr detail::_as_val_fn _as_val{};
 inline constexpr detail::_where_fn _where{};
 inline constexpr detail::_attr_fn _attr{};
 

--- a/include/boost/spirit/x4/core/detail/parse_into_container.hpp
+++ b/include/boost/spirit/x4/core/detail/parse_into_container.hpp
@@ -270,8 +270,8 @@ struct parse_into_container_impl<Parser, Context>
         Context const& ctx, Attr& attr
     ) // never noexcept (requires container insertion)
     {
-        static_assert(!std::is_same_v<std::remove_const_t<Attr>, unused_type>);
-        static_assert(!std::is_same_v<std::remove_const_t<Attr>, unused_container_type>);
+        static_assert(!std::same_as<std::remove_const_t<Attr>, unused_type>);
+        static_assert(!std::same_as<std::remove_const_t<Attr>, unused_container_type>);
 
         static_assert(Parsable<Parser, It, Se, Context, Attr>);
 
@@ -284,8 +284,8 @@ struct parse_into_container_impl<Parser, Context>
 
         traits::append(
             attr,
-            std::make_move_iterator(std::ranges::begin(rest)),
-            std::make_move_iterator(std::ranges::end(rest))
+            std::make_move_iterator(traits::begin(rest)),
+            std::make_move_iterator(traits::end(rest))
         );
         return true;
     }

--- a/include/boost/spirit/x4/core/move_to.hpp
+++ b/include/boost/spirit/x4/core/move_to.hpp
@@ -263,6 +263,11 @@ move_to(Source&& src, Dest& dest)
     x4::move_to(std::forward<Source>(src), fusion::front(dest));
 }
 
+template<class Source, class Dest>
+concept X4Movable = requires {
+    x4::move_to(std::declval<Source>(), std::declval<Dest&>());
+};
+
 } // boost::spirit::x4
 
 #endif

--- a/include/boost/spirit/x4/directive/as.hpp
+++ b/include/boost/spirit/x4/directive/as.hpp
@@ -1,0 +1,160 @@
+﻿#ifndef BOOST_SPIRIT_X4_DIRECTIVE_AS_HPP
+#define BOOST_SPIRIT_X4_DIRECTIVE_AS_HPP
+
+#include <boost/spirit/x4/core/parser.hpp>
+#include <boost/spirit/x4/core/move_to.hpp>
+#include <boost/spirit/x4/core/unused.hpp>
+
+#include <concepts>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x4 {
+
+namespace detail {
+
+template<bool NeedAsVal, class Context, X4Attribute Attr>
+struct as_directive_ctx_impl // false
+{
+    using type = Context;
+};
+template<class Context, X4Attribute Attr>
+struct as_directive_ctx_impl<true, Context, Attr>
+{
+    using type = std::remove_cvref_t<decltype(x4::replace_first_context<contexts::as_val>(
+        std::declval<Context const&>(),
+        std::declval<Attr&>()
+    ))>;
+};
+
+} // detail
+
+// `as_directive` forces the attribute of subject parser
+// to be `T`. When `T` is `unused_type`, this is equivalent to
+// `omit_directive`.
+template<X4Attribute T, class Subject>
+struct as_directive : unary_parser<Subject, as_directive<T, Subject>>
+{
+    static_assert(!std::is_const_v<T>); // Forbid const `unused_type`
+    static_assert(!std::same_as<T, unused_container_type>); // Unknown use case, not supported for now
+
+    static_assert(std::default_initializable<T>);
+
+    using base_type = unary_parser<Subject, as_directive>;
+    using attribute_type = T;
+    using subject_type = Subject;
+
+    static constexpr bool has_attribute = !std::same_as<T, unused_type>;
+    static constexpr bool has_action = false; // Important: explicitly re-enable attribute detection in `x4::rule`
+
+private:
+    static constexpr bool need_as_val = Subject::has_action;
+
+public:
+    template<class SubjectT>
+        requires
+            (!std::is_same_v<std::remove_cvref_t<SubjectT>, as_directive>) &&
+            std::is_constructible_v<base_type, SubjectT>
+    constexpr as_directive(SubjectT&& subject)
+        noexcept(std::is_nothrow_constructible_v<base_type, SubjectT>)
+        : base_type(std::forward<SubjectT>(subject))
+    {}
+
+    // `as<T>(as<T>(subject))` forwards the outer `T&` for `subject`
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute OuterAttr>
+        requires std::same_as<std::remove_const_t<OuterAttr>, T>
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, OuterAttr& outer_attr) const
+        noexcept(is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_val, Context, OuterAttr>::type, OuterAttr>)
+    {
+        if constexpr (need_as_val) {
+            return this->subject.parse(first, last, x4::replace_first_context<contexts::as_val>(ctx, outer_attr), outer_attr);
+        } else {
+            return this->subject.parse(first, last, ctx, outer_attr);
+        }
+    }
+
+    // `as<unused_type>(as<T>(subject))` gives `unused_type` for `subject`
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4UnusedAttribute OuterAttr>
+        requires
+            (!std::same_as<std::remove_const_t<OuterAttr>, T>)
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, OuterAttr&) const
+        noexcept(is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_val, Context, unused_type>::type, unused_type>)
+    {
+        if constexpr (need_as_val) {
+            return this->subject.parse(first, last, x4::replace_first_context<contexts::as_val>(ctx, unused), unused);
+        } else {
+            return this->subject.parse(first, last, ctx, unused);
+        }
+    }
+
+    // `as<U>(as<T>(subject))` gives `T` for `subject`, then move `T&&` to `U&`
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4NonUnusedAttribute OuterAttr>
+        requires
+            (!std::same_as<std::remove_const_t<OuterAttr>, T>) &&
+            X4Movable<T, OuterAttr>
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, OuterAttr& outer_attr) const
+        noexcept(
+            is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_val, Context, T>::type, T> &&
+            noexcept(x4::move_to(std::declval<T>(), outer_attr))
+        )
+    {
+        // Ideally we should default to default-initialization and avoid value-initialization.
+        // However, there is currently no way to determine whether the attribute is ever touched
+        // by the underlying parser (for example: semantic action).
+        //
+        // Note that this behavior is our implementation details. The underlying parser should
+        // not rely on this behavior; they should never assume the given attribute is defaulted
+        // to some arbitrary initial value.
+
+        T attr_{}; // value-initialize
+
+        if constexpr (need_as_val) {
+            if (!this->subject.parse(first, last, x4::replace_first_context<contexts::as_val>(ctx, attr_), attr_)) return false;
+        } else {
+            if (!this->subject.parse(first, last, ctx, attr_)) return false;
+        }
+
+        x4::move_to(std::move(attr_), outer_attr);
+        return true;
+    }
+
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4NonUnusedAttribute OuterAttr>
+        requires
+            (!std::same_as<std::remove_const_t<OuterAttr>, T>) &&
+            (!X4Movable<T, OuterAttr>)
+    constexpr void
+    parse(It&, Se const&, Context const&, OuterAttr&) const = delete; // `T` is not movable to the exposed attribute
+};
+
+namespace detail {
+
+template<X4Attribute T>
+struct as_fn
+{
+    template<X4Subject Subject>
+    [[nodiscard]] static constexpr as_directive<T, as_parser_plain_t<Subject>>
+    operator()(Subject&& subject)
+        noexcept(is_parser_nothrow_constructible_v<as_directive<T, as_parser_plain_t<Subject>>, Subject>)
+    {
+        return {std::forward<Subject>(subject)};
+    }
+};
+
+} // detail
+
+namespace parsers::directive {
+
+template<X4Attribute T>
+inline constexpr detail::as_fn<T> as{};
+
+} // parsers::directive
+
+using parsers::directive::as;
+
+} // boost::spirit::x4
+
+#endif

--- a/include/boost/spirit/x4/traits/attribute_category.hpp
+++ b/include/boost/spirit/x4/traits/attribute_category.hpp
@@ -79,7 +79,8 @@ struct attribute_category<unused_container_type>
 
 template<class T, typename AttrCategoryTag>
 concept CategorizedAttr =
-    std::same_as<typename attribute_category<std::remove_cvref_t<T>>::type, AttrCategoryTag>;
+    // Don't use `std::same_as` here, it bloats the compilation error.
+    std::is_same_v<typename attribute_category<std::remove_cvref_t<T>>::type, AttrCategoryTag>;
 
 template<class T>
 concept NonUnusedAttr = !CategorizedAttr<T, unused_attr>;

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -52,6 +52,7 @@ x4_define_tests(
     actions
     alternative
     and_predicate
+    as
     attr
     attribute
     attribute_type_check

--- a/test/x4/Jamfile
+++ b/test/x4/Jamfile
@@ -96,6 +96,7 @@ run omit.cpp catch2 ;
 run optional.cpp catch2 ;
 run plus.cpp catch2 ;
 run with.cpp catch2 ;
+run as.cpp catch2 ;
 
 run raw.cpp catch2 ;
 run real1.cpp catch2 ;

--- a/test/x4/as.cpp
+++ b/test/x4/as.cpp
@@ -1,0 +1,282 @@
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "test.hpp"
+
+#include <boost/spirit/x4/auxiliary/attr.hpp>
+#include <boost/spirit/x4/auxiliary/eps.hpp>
+#include <boost/spirit/x4/directive/as.hpp>
+#include <boost/spirit/x4/char/char.hpp>
+#include <boost/spirit/x4/char/char_class.hpp>
+#include <boost/spirit/x4/char/negated_char.hpp>
+#include <boost/spirit/x4/string/string.hpp>
+#include <boost/spirit/x4/operator/sequence.hpp>
+#include <boost/spirit/x4/operator/alternative.hpp>
+#include <boost/spirit/x4/operator/kleene.hpp>
+#include <boost/spirit/x4/numeric/int.hpp>
+#include <boost/spirit/x4/rule.hpp>
+
+#include <string>
+#include <string_view>
+#include <concepts>
+#include <type_traits>
+
+// NOLINTBEGIN(readability-container-size-empty)
+
+TEST_CASE("as")
+{
+    using namespace std::string_view_literals;
+
+    using x4::eps;
+    using x4::string;
+    using x4::_attr;
+    using x4::_val;
+    using x4::_as_val;
+
+    using It = std::string_view::const_iterator;
+    using Se = It;
+    using Context = unused_type;
+
+    // as<unused_type>
+    {
+        constexpr auto p = x4::as<unused_type>(eps);
+        using Underlying = std::remove_const_t<decltype(eps)>;
+        using AsParser = std::remove_const_t<decltype(p)>;
+
+        static_assert(std::same_as<x4::traits::attribute_of_t<Underlying, Context>, unused_type>);
+
+        static_assert(x4::is_nothrow_parsable_v<Underlying, It, Se, Context, unused_type>);
+        static_assert(x4::is_nothrow_parsable_v<Underlying, It, Se, Context, std::string>); // Arbitrary exposed attribute
+
+        static_assert(x4::is_nothrow_parsable_v<AsParser, It, Se, Context, unused_type>);
+        static_assert(x4::is_nothrow_parsable_v<AsParser, It, Se, Context, std::string>); // Arbitrary exposed attribute
+
+        std::string_view input;
+        It first = input.begin();
+        Se const last = input.end();
+        std::string attr;
+        (void)p.parse(first, last, unused, unused);
+        (void)p.parse(first, last, unused, attr);
+    }
+
+    // as<int>
+    {
+        constexpr auto p = x4::as<int>(eps);
+        using Underlying = std::remove_const_t<decltype(eps)>;
+        using AsParser = std::remove_const_t<decltype(p)>;
+
+        static_assert(std::same_as<x4::traits::attribute_of_t<Underlying, Context>, unused_type>);
+
+        static_assert(x4::is_nothrow_parsable_v<Underlying, It, Se, Context, unused_type>);
+        static_assert(x4::is_nothrow_parsable_v<Underlying, It, Se, Context, std::string>); // Arbitrary exposed attribute
+
+        static_assert(x4::is_nothrow_parsable_v<AsParser, It, Se, Context, unused_type>);
+        static_assert(x4::is_nothrow_parsable_v<AsParser, It, Se, Context, long>); // Arbitrary exposed attribute
+
+        std::string_view input;
+        It first = input.begin();
+        Se const last = input.end();
+        long attr = 0;
+        (void)p.parse(first, last, unused, unused);
+        (void)p.parse(first, last, unused, attr);
+    }
+
+    constexpr auto disable_attr = eps[([](auto&) {})];
+    constexpr auto quoted_string = '\'' >> *~x4::char_('\'') >> '\'';
+
+    // `as` only
+    {
+        std::string attr;
+        REQUIRE(parse("'foo'", quoted_string, attr));
+        CHECK(attr == "foo"sv);
+    }
+    {
+        std::string attr;
+        REQUIRE(parse("'foo'", x4::as<std::string>(quoted_string), attr));
+        CHECK(attr == "foo"sv);
+    }
+
+    {
+        std::string attr;
+        REQUIRE(parse("'fo", quoted_string | x4::string("'fo"), attr));
+        CHECK(attr == "'fo"sv);
+    }
+    {
+        std::string attr;
+        REQUIRE(parse("'fo", x4::as<std::string>(quoted_string) | x4::string("'fo"), attr));
+        CHECK(attr == "'fo"sv);
+    }
+
+    // `as` + `rule`
+    {
+        constexpr x4::rule<struct _, std::string> rule_maker{"rule_maker"};
+
+        // Non-forced attribute, `operator=`
+        {
+            // Attribute is disabled because the sub parser has semantic action and the operator is `=`
+            constexpr auto rule_without_attr = rule_maker = quoted_string >> disable_attr;
+            std::string str;
+            REQUIRE(parse("'foo'", rule_without_attr, str));
+            CHECK(str == ""sv); // Disabled attribute should yield default-constructed attribute
+        }
+        {
+            // Attribute is disabled because the sub parser has semantic action and the operator is `=`
+            constexpr auto rule_without_attr = rule_maker = x4::as<std::string>(quoted_string) >> disable_attr;
+            std::string str;
+            REQUIRE(parse("'foo'", rule_without_attr, str));
+            CHECK(str == ""sv); // Disabled attribute should yield default-constructed attribute
+        }
+        {
+            // Attribute is forced because `as_directive` sets `::has_action` to `false`
+            constexpr auto rule_without_attr = rule_maker = x4::as<std::string>(quoted_string >> disable_attr);
+            std::string str;
+            REQUIRE(parse("'foo'", rule_without_attr, str));
+            CHECK(str == "foo"sv); // Forced attribute should hold the parsed value
+        }
+
+        // Forced attribute, `operator%=`
+        {
+            constexpr auto rule_with_forced_attr = rule_maker %= quoted_string >> disable_attr;
+            std::string str;
+            REQUIRE(parse("'foo'", rule_with_forced_attr, str));
+            CHECK(str == "foo"sv); // Forced attribute should hold the parsed value
+        }
+        {
+            constexpr auto rule_with_forced_attr = rule_maker %= x4::as<std::string>(quoted_string) >> disable_attr;
+            std::string str;
+            REQUIRE(parse("'foo'", rule_with_forced_attr, str));
+            CHECK(str == "foo"sv); // `as` should not create a temporary; it should directly parse into the exposed variable
+        }
+        {
+            constexpr auto rule_with_forced_attr = rule_maker %= x4::as<std::string>(quoted_string >> disable_attr);
+            std::string str;
+            REQUIRE(parse("'foo'", rule_with_forced_attr, str));
+            CHECK(str == "foo"sv); // `as` should not create a temporary; it should directly parse into the exposed variable
+        }
+    }
+
+    // `as_val(ctx)` (with auto attribute propagation)
+    {
+        std::string result;
+
+        constexpr auto string_rule = x4::rule<struct _, decltype(result)>{""} =
+            x4::as<std::string>(
+                eps[([](auto& ctx) {
+                    _val(ctx) = "default";
+                })] >>
+
+                eps[([](auto& ctx) {
+                    _as_val(ctx) = "foo";
+                })]
+            );
+
+        std::string_view const input;
+        It first = input.begin();
+        Se const last = input.end();
+
+        REQUIRE(string_rule.parse(first, last, unused, result));
+        CHECK(result == "foo"sv);
+    }
+    // `as_val(ctx)` (with disabled attribute)
+    {
+        std::string result;
+
+        constexpr auto string_rule = x4::rule<struct _, decltype(result)>{""} =
+            x4::as<std::string>(
+                eps[([](auto& ctx) {
+                    _val(ctx) = "default";
+                })] >>
+
+                eps[([]([[maybe_unused]] auto& ctx) {
+                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
+                })]
+            ) >> disable_attr; // <----------
+
+        std::string_view const input;
+        It first = input.begin();
+        Se const last = input.end();
+
+        REQUIRE(string_rule.parse(first, last, unused, result));
+        CHECK(result == "default"sv);
+    }
+    // `as_val(ctx)` (within `as<unused_type>(as<std::string>(...))`)
+    {
+        std::string result{"default"};
+
+        constexpr auto unused_rule = x4::as<unused_type>(
+            x4::as<std::string>(
+                eps[([]([[maybe_unused]] auto& ctx) {
+                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
+                })]
+            )
+        );
+
+        std::string_view const input;
+        It first = input.begin();
+        Se const last = input.end();
+
+        REQUIRE(unused_rule.parse(first, last, unused, result));
+        CHECK(result == "default"sv);
+    }
+    // `as_val(ctx)` (within `as<std::string>(as<unused_type>(...))`)
+    {
+        std::string result;
+
+        /*constexpr*/ auto unused_rule = x4::as<std::string>(
+            x4::attr("default") >>
+
+            eps[([]([[maybe_unused]] auto& ctx) {
+                static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, std::string>);
+            })] >>
+
+            x4::as<unused_type>(
+                eps[([]([[maybe_unused]] auto& ctx) {
+                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
+                })]
+            )
+        );
+
+        std::string_view const input;
+        It first = input.begin();
+        Se const last = input.end();
+
+        REQUIRE(unused_rule.parse(first, last, unused, result));
+        CHECK(result == "default"sv);
+    }
+
+    // Use `_val(ctx)` inside `as<T>(...)`
+    {
+        struct StringLiteral
+        {
+            bool is_quoted = false;
+            std::string text;
+        };
+
+        StringLiteral result;
+
+        constexpr auto string_literal = x4::rule<struct _, StringLiteral>{"StringLiteral"} =
+            eps[([](auto& ctx) { _val(ctx).is_quoted = false; })] >>
+            x4::as<std::string>(
+                x4::lit('"')[([](auto& ctx) {
+                    StringLiteral& rule_val = _val(ctx);
+                    rule_val.is_quoted = true;
+                })] >>
+                *~x4::char_('"') >>
+                '"'
+            )[([](auto& ctx) { _val(ctx).text = std::move(_attr(ctx)); })];
+
+        std::string_view input = R"("foo")";
+        It first = input.begin();
+        Se const last = input.end();
+
+        REQUIRE(string_literal.parse(first, last, unused, result));
+        CHECK(result.is_quoted == true);
+        CHECK(result.text == "foo"sv);
+    }
+}
+
+// NOLINTEND(readability-container-size-empty)

--- a/test/x4/context.cpp
+++ b/test/x4/context.cpp
@@ -94,12 +94,12 @@ TEST_CASE("context")
 
         {
             auto&& removed_ctx = x4::remove_first_context<existent_tag>(ctx);
-            STATIC_CHECK(std::same_as<decltype(removed_ctx), x4::detail::monostate_context&&>);
+            STATIC_CHECK(std::same_as<decltype(removed_ctx), unused_type&&>);
 
             // monostate tests
             {
                 auto&& mono_removed_ctx = x4::remove_first_context<non_existent_tag>(removed_ctx);
-                STATIC_CHECK(std::same_as<decltype(mono_removed_ctx), x4::detail::monostate_context const&>);
+                STATIC_CHECK(std::same_as<decltype(mono_removed_ctx), unused_type const&>);
                 (void)mono_removed_ctx;
             }
             {
@@ -193,11 +193,11 @@ TEST_CASE("context")
             }
             {
                 auto&& removed_ctx = x4::remove_first_context<existent_tag>(replaced_ctx);
-                STATIC_CHECK(std::same_as<decltype(removed_ctx), x4::detail::monostate_context&&>);
+                STATIC_CHECK(std::same_as<decltype(removed_ctx), unused_type&&>);
 
                 {
                     [[maybe_unused]] auto&& removed_removed_ctx = x4::remove_first_context<existent_tag>(removed_ctx);
-                    STATIC_CHECK(std::same_as<decltype(removed_removed_ctx), x4::detail::monostate_context const&>);
+                    STATIC_CHECK(std::same_as<decltype(removed_removed_ctx), unused_type const&>);
                 }
                 {
                     [[maybe_unused]] auto&& new_ctx = x4::make_context<existent_tag>(i, removed_ctx);


### PR DESCRIPTION
Part of #1 

This PR implements `x4::as<T>(...)` directive.

## Previously well-known technique: `x3::rule<_, T>{} = ...`

For a long period of time, people were (ab)using `x3::rule<_, T>{} =` for this purpose:

```cpp
template<class T, class P>
constexpr auto easy_as(P&& p)
{
    return x3::rule<struct _, T>{} = std::forward<P>(p);
}

constexpr auto my_parser = easy_as<std::string>('"' >> *~char_('"') >> '"');
```

Although not officially supported, this was the very common technique seen in Stack Overflow. However, it has many drawbacks:

- In the first place, such primitive directive should be supported out-of-the-box.
- It is abusing `x3::rule`, which is overkill due to what `rule` actually does in its implementation details.
- It _pollutes_ the `_val` context, which makes it unable to fetch the _real_ `_val` attribute bound to the outer grammar.
- It was unclear how the nested call `easy_as<U>(easy_as<T>(...))` behaves.

## Our approach: `struct x4::as_directive`

This PR adds a full parser class `x4::as_directive` which has exactly the semantics that I believe it should have.

- `_val` is untouched; `_as_val` is provided
- `as<T>(...)` always sets `::has_action = false`, which re-enables attribute propagation even for `as<T>(p[f])` 
- `as<T>(as<T>(subject))` forwards the outer `T&` (exposed attribute) for `subject`. No temporary variable is created.
- `as<unused_type>(as<T>(subject))` gives `unused_type` for `subject`.
- `as<U>(as<T>(subject))` gives `T` for `subject`, then move `T&&` to `U&`. This is the only case where the `as_directive` creates a temporary variable.