### PR TITLE
Make `rcontext` only when required

### DIFF
--- a/include/boost/spirit/x4/core/action.hpp
+++ b/include/boost/spirit/x4/core/action.hpp
@@ -93,6 +93,7 @@ struct action : unary_parser<Subject, action<Subject, Action>>
     using base_type = unary_parser<Subject, action<Subject, Action>>;
     static constexpr bool is_pass_through_unary = true;
     static constexpr bool has_action = true;
+    static constexpr bool need_rcontext = true;
 
     Action f;
 

--- a/include/boost/spirit/x4/core/parser.hpp
+++ b/include/boost/spirit/x4/core/parser.hpp
@@ -47,6 +47,7 @@ struct parser : private detail::parser_base
     static constexpr bool handles_container = false;
     static constexpr bool is_pass_through_unary = false;
     static constexpr bool has_action = false;
+    static constexpr bool need_rcontext = false;
 
     [[nodiscard]] constexpr Derived& derived() & noexcept
     {
@@ -92,6 +93,7 @@ struct unary_parser : parser<Derived>
     using subject_type = Subject;
 
     static constexpr bool has_action = Subject::has_action;
+    static constexpr bool need_rcontext = Subject::need_rcontext;
 
     constexpr unary_parser() = default;
 
@@ -114,6 +116,7 @@ struct binary_parser : parser<Derived>
     using right_type = Right;
 
     static constexpr bool has_action = left_type::has_action || right_type::has_action;
+    static constexpr bool need_rcontext = left_type::need_rcontext || right_type::need_rcontext;
 
     constexpr binary_parser() = default;
 

--- a/include/boost/spirit/x4/directive/as.hpp
+++ b/include/boost/spirit/x4/directive/as.hpp
@@ -46,7 +46,7 @@ struct as_directive : unary_parser<Subject, as_directive<T, Subject>>
     using subject_type = Subject;
 
     static constexpr bool has_attribute = !std::same_as<T, unused_type>;
-    static constexpr bool has_action = false; // Important: explicitly re-enable attribute detection in `x4::rule`
+    static constexpr bool has_action = false; // Explicitly re-enable attribute detection in `x4::rule`
 
 private:
     static constexpr bool need_as_val = Subject::has_action;


### PR DESCRIPTION
Part of #1 
Follow-up for #37 

X3 had created `rcontext` unconditionally for any parser invocations. That led X4 to do the same even after #37 was merged. This commit further optimizes the implementation to create `rcontext` only when it is required by the underlying parser. Conditions are:

- `RHS` utilizes semantic action, or
- `RuleID` has `RuleID::on_success(...)`, or
- `RuleID` has `RuleID::on_error(...)`.

This optimization resolves the last runtime overhead mentioned in #11, where the additional reference bound to `_val` was materialized regardless of whether it is actually used by the underlying parser.

Note that the `as<T>(...)` directive (#53) has a special case handling that hides the existence of semantic action in the underlying parser. This commit adds the new static bool trait `::need_rcontext` to detect such cases.