### PR TITLE
Remove `_pass(ctx)`, return bool directly from semantic action

### DIFF
--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -16,12 +16,6 @@ namespace boost::spirit::x4 {
 
 namespace contexts {
 
-// _pass
-struct parse_pass
-{
-    static constexpr bool is_unique = true;
-};
-
 // _val
 // Refers to the attribute of `x4::rule`.
 // This always points to the *innermost* attribute for the (potentially recursive) invocation of `x4::rule`.
@@ -54,7 +48,6 @@ struct attr
 
 } // contexts
 
-using parse_pass_context_tag [[deprecated("Use `x4::contexts::parse_pass`")]] = contexts::parse_pass;
 using rule_val_context_tag [[deprecated("Use `x4::contexts::rule_val`")]] = contexts::rule_val;
 using where_context_tag [[deprecated("Use `x4::contexts::where`")]] = contexts::where;
 using attr_context_tag [[deprecated("Use `x4::contexts::attr`")]] = contexts::attr;
@@ -65,14 +58,8 @@ namespace detail {
 struct _pass_fn
 {
     template<class Context>
-    [[nodiscard]] static constexpr bool&
-    operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
-    {
-        return x4::get<contexts::parse_pass>(ctx);
-    }
-
-    template<class Context>
-    static void operator()(Context const&&) = delete; // dangling
+    static constexpr void
+    operator()(Context const&) = delete; // `_pass(ctx)` is obsolete. Just return bool from semantic action.
 };
 
 struct _val_fn

--- a/test/x4/actions.cpp
+++ b/test/x4/actions.cpp
@@ -26,7 +26,7 @@ TEST_CASE("action")
         CHECK(parse("{42}", '{' >> int_[fun_action] >> '}'));
     }
     {
-        auto const fail = [](auto& ctx) { x4::_pass(ctx) = false; };
+        auto const fail = [](auto&) { return false; };
         std::string input("1234 6543");
         char next = '\0';
 

--- a/test/x4/iterator.cpp
+++ b/test/x4/iterator.cpp
@@ -214,14 +214,14 @@ TEST_CASE("rollback on failed parse (action)")
     {
         constexpr auto input = "foo"sv;
         auto first = input.begin();
-        REQUIRE_FALSE(eps[([](auto& ctx) { _pass(ctx) = false; })].parse(first, input.end(), unused, unused));
+        REQUIRE_FALSE(eps[([](auto&) { return false; })].parse(first, input.end(), unused, unused));
         CHECK(first == input.begin());
     }
     {
         constexpr auto input = "42"sv;
         auto first = input.begin();
         int dummy_int = -1;
-        REQUIRE_FALSE(int_[([](auto& ctx) { _pass(ctx) = false; })].parse(first, input.end(), unused, dummy_int));
+        REQUIRE_FALSE(int_[([](auto&) { return false; })].parse(first, input.end(), unused, dummy_int));
         CHECK(first == input.begin());
         CHECK(dummy_int == 42); // sequence parser itself succeeds; always results in side effect
     }
@@ -229,7 +229,7 @@ TEST_CASE("rollback on failed parse (action)")
         constexpr auto input = "42,43"sv;
         auto first = input.begin();
         std::vector<int> dummy_ints;
-        REQUIRE_FALSE((int_ >> ',' >> int_)[([](auto& ctx) { _pass(ctx) = false; })].parse(first, input.end(), unused, dummy_ints));
+        REQUIRE_FALSE((int_ >> ',' >> int_)[([](auto&) { return false; })].parse(first, input.end(), unused, dummy_ints));
         CHECK(first == input.begin());
         CHECK(dummy_ints == std::vector<int>{42, 43}); // sequence parser itself succeeds; always results in side effect
     }

--- a/test/x4/with.cpp
+++ b/test/x4/with.cpp
@@ -46,14 +46,13 @@ struct match_counter_rule_id
 using x4::rule;
 using x4::int_;
 using x4::with;
-using x4::_pass;
 using x4::_attr;
 
 template<class T>
 constexpr auto value_equals = int_[([](auto& ctx) {
     auto&& with_val = x4::get<my_tag>(ctx);
     static_assert(std::same_as<decltype(with_val), T>);
-    _pass(ctx) = with_val == _attr(ctx);
+    return with_val == _attr(ctx);
 })];
 
 } // anonymous


### PR DESCRIPTION
Part of #1 

This removes one reference variable bound to the context, which is a huge runtime performance gain.