### PR TITLE
Add `[[maybe_unused]]` to all inline variables

### DIFF
--- a/include/boost/spirit/x4/auxiliary/attr.hpp
+++ b/include/boost/spirit/x4/auxiliary/attr.hpp
@@ -121,7 +121,7 @@ struct attr_gen
 
 namespace parsers {
 
-inline constexpr detail::attr_gen attr{};
+[[maybe_unused]] inline constexpr detail::attr_gen attr{};
 
 } // parsers
 

--- a/include/boost/spirit/x4/auxiliary/eoi.hpp
+++ b/include/boost/spirit/x4/auxiliary/eoi.hpp
@@ -46,7 +46,7 @@ struct get_info<eoi_parser>
 
 namespace parsers {
 
-inline constexpr eoi_parser eoi{};
+[[maybe_unused]] inline constexpr eoi_parser eoi{};
 
 } // parsers
 

--- a/include/boost/spirit/x4/auxiliary/eol.hpp
+++ b/include/boost/spirit/x4/auxiliary/eol.hpp
@@ -58,7 +58,7 @@ struct get_info<eol_parser>
 
 namespace parsers {
 
-inline constexpr eol_parser eol{};
+[[maybe_unused]] inline constexpr eol_parser eol{};
 
 } // parsers
 

--- a/include/boost/spirit/x4/binary.hpp
+++ b/include/boost/spirit/x4/binary.hpp
@@ -115,7 +115,7 @@ struct any_binary_parser : parser<any_binary_parser<T, endian, bits>>
 
 #define BOOST_SPIRIT_X4_BINARY_PARSER(name, endiantype, attrtype, bits) \
     namespace parsers { \
-    inline constexpr any_binary_parser<attrtype, boost::endian::order::endiantype, bits> name{}; \
+    [[maybe_unused]] inline constexpr any_binary_parser<attrtype, boost::endian::order::endiantype, bits> name{}; \
     } /* parsers */ \
     using parsers::name;
 

--- a/include/boost/spirit/x4/char/char.hpp
+++ b/include/boost/spirit/x4/char/char.hpp
@@ -27,7 +27,7 @@ namespace boost::spirit::x4 {
 
 namespace standard {
 
-inline constexpr any_char<char_encoding::standard> char_{};
+[[maybe_unused]] inline constexpr any_char<char_encoding::standard> char_{};
 
 inline namespace helpers {
 
@@ -55,14 +55,16 @@ constexpr void lit(traits::CharIncompatibleWith<char> auto) = delete; // Mixing 
 
 } // standard
 
-inline constexpr auto const& char_ = standard::char_; // TODO: this can't overload other character types
+
+[[maybe_unused]] inline constexpr auto const& char_ = standard::char_; // TODO: this can't overload other character types
+
 using standard::helpers::lit;
 
 
 #ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
 namespace standard_wide {
 
-inline constexpr any_char<char_encoding::standard_wide> char_{};
+[[maybe_unused]] inline constexpr any_char<char_encoding::standard_wide> char_{};
 
 inline namespace helpers {
 
@@ -92,7 +94,7 @@ using standard_wide::helpers::lit;
 #ifdef BOOST_SPIRIT_X4_UNICODE
 namespace unicode {
 
-inline constexpr any_char<char_encoding::unicode> char_{};
+[[maybe_unused]] inline constexpr any_char<char_encoding::unicode> char_{};
 
 inline namespace helpers {
 

--- a/include/boost/spirit/x4/char_encoding/unicode/detail/category_table.hpp
+++ b/include/boost/spirit/x4/char_encoding/unicode/detail/category_table.hpp
@@ -12,7 +12,7 @@
 
 namespace boost::spirit::x4::unicode::detail {
 
-inline constexpr std::uint8_t category_stage1[] = {
+[[maybe_unused]] inline constexpr std::uint8_t category_stage1[] = {
       0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
      16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,  31,
      32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  34,  42,  43,  44,  45,  46,
@@ -287,7 +287,7 @@ inline constexpr std::uint8_t category_stage1[] = {
      61,  61,  61,  61,  61,  61,  61,  61,  61,  61,  61,  61,  61,  61,  61, 158
 };
 
-inline constexpr std::uint16_t category_stage2[] = {
+[[maybe_unused]] inline constexpr std::uint16_t category_stage2[] = {
     // block 0
       32,   32,   32,   32,   32,   32,   32,   32,   32,  544,  544,  544,  544,  544,   32,   32,
       32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,   32,

--- a/include/boost/spirit/x4/char_encoding/unicode/detail/lowercase_table.hpp
+++ b/include/boost/spirit/x4/char_encoding/unicode/detail/lowercase_table.hpp
@@ -12,7 +12,7 @@
 
 namespace boost::spirit::x4::unicode::detail {
 
-inline constexpr std::uint8_t lowercase_stage1[] = {
+[[maybe_unused]] inline constexpr std::uint8_t lowercase_stage1[] = {
       0,   1,   2,   3,   4,   5,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,
       7,   6,   6,   8,   6,   6,   6,   6,   6,   6,   6,   6,   9,   6,  10,  11,
       6,  12,   6,   6,  13,   6,   6,   6,   6,   6,   6,   6,  14,   6,   6,   6,
@@ -287,7 +287,7 @@ inline constexpr std::uint8_t lowercase_stage1[] = {
       6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6
 };
 
-inline constexpr std::uint32_t lowercase_stage2[] = {
+[[maybe_unused]] inline constexpr std::uint32_t lowercase_stage2[] = {
     // block 0
          0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
          0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,

--- a/include/boost/spirit/x4/char_encoding/unicode/detail/script_table.hpp
+++ b/include/boost/spirit/x4/char_encoding/unicode/detail/script_table.hpp
@@ -12,7 +12,7 @@
 
 namespace boost::spirit::x4::unicode::detail {
 
-inline constexpr std::uint8_t script_stage1[] = {
+[[maybe_unused]] inline constexpr std::uint8_t script_stage1[] = {
       0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,
      16,  17,  18,  19,  20,  20,  21,  22,  23,  24,  25,  26,  27,  28,   1,  29,
      30,  31,  32,  32,  33,  32,  32,  32,  34,  32,  32,  35,  36,  37,  38,  39,
@@ -287,7 +287,7 @@ inline constexpr std::uint8_t script_stage1[] = {
      56,  56,  56,  56,  56,  56,  56,  56,  56,  56,  56,  56,  56,  56,  56,  56
 };
 
-inline constexpr std::uint8_t script_stage2[] = {
+[[maybe_unused]] inline constexpr std::uint8_t script_stage2[] = {
     // block 0
     163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163,
     163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163, 163,

--- a/include/boost/spirit/x4/char_encoding/unicode/detail/uppercase_table.hpp
+++ b/include/boost/spirit/x4/char_encoding/unicode/detail/uppercase_table.hpp
@@ -12,7 +12,7 @@
 
 namespace boost::spirit::x4::unicode::detail {
 
-inline constexpr std::uint8_t uppercase_stage1[] = {
+[[maybe_unused]] inline constexpr std::uint8_t uppercase_stage1[] = {
       0,   1,   2,   3,   4,   5,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,
       7,   6,   6,   8,   6,   6,   6,   6,   6,   6,   6,   6,   9,  10,  11,  12,
       6,  13,   6,   6,  14,   6,   6,   6,   6,   6,   6,   6,  15,  16,   6,   6,
@@ -287,7 +287,7 @@ inline constexpr std::uint8_t uppercase_stage1[] = {
       6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6,   6
 };
 
-inline constexpr std::uint32_t uppercase_stage2[] = {
+[[maybe_unused]] inline constexpr std::uint32_t uppercase_stage2[] = {
     // block 0
          0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,
          0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,      0,

--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -118,11 +118,11 @@ struct _attr_fn
 
 inline namespace cpos {
 
-inline constexpr detail::_pass_fn _pass{};
-inline constexpr detail::_val_fn _val{};
-inline constexpr detail::_as_val_fn _as_val{};
-inline constexpr detail::_where_fn _where{};
-inline constexpr detail::_attr_fn _attr{};
+[[maybe_unused]] inline constexpr detail::_pass_fn _pass{};
+[[maybe_unused]] inline constexpr detail::_val_fn _val{};
+[[maybe_unused]] inline constexpr detail::_as_val_fn _as_val{};
+[[maybe_unused]] inline constexpr detail::_where_fn _where{};
+[[maybe_unused]] inline constexpr detail::_attr_fn _attr{};
 
 } // cpos
 

--- a/include/boost/spirit/x4/core/parser.hpp
+++ b/include/boost/spirit/x4/core/parser.hpp
@@ -252,7 +252,7 @@ struct as_parser_fn
 
 inline namespace cpos {
 
-inline constexpr detail::as_parser_fn as_parser{};
+[[maybe_unused]] inline constexpr detail::as_parser_fn as_parser{};
 
 } // cpos
 
@@ -511,7 +511,7 @@ struct what_fn
 
 inline namespace cpos {
 
-inline constexpr detail::what_fn what{}; // no ADL
+[[maybe_unused]] inline constexpr detail::what_fn what{}; // no ADL
 
 } // cpos
 

--- a/include/boost/spirit/x4/core/unused.hpp
+++ b/include/boost/spirit/x4/core/unused.hpp
@@ -45,8 +45,8 @@ struct unused_container_type
 
 inline namespace cpos {
 
-inline constexpr unused_type unused{};
-inline constexpr unused_container_type unused_container{};
+[[maybe_unused]] inline constexpr unused_type unused{};
+[[maybe_unused]] inline constexpr unused_container_type unused_container{};
 
 } // cpos
 

--- a/include/boost/spirit/x4/directive/as.hpp
+++ b/include/boost/spirit/x4/directive/as.hpp
@@ -139,7 +139,7 @@ struct as_fn
 namespace parsers::directive {
 
 template<X4Attribute T>
-inline constexpr detail::as_fn<T> as{};
+[[maybe_unused]] inline constexpr detail::as_fn<T> as{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/expect.hpp
+++ b/include/boost/spirit/x4/directive/expect.hpp
@@ -64,7 +64,7 @@ struct expect_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::expect_gen expect{};
+[[maybe_unused]] inline constexpr detail::expect_gen expect{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/lexeme.hpp
+++ b/include/boost/spirit/x4/directive/lexeme.hpp
@@ -81,7 +81,7 @@ struct lexeme_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::lexeme_gen lexeme{};
+[[maybe_unused]] inline constexpr detail::lexeme_gen lexeme{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/matches.hpp
+++ b/include/boost/spirit/x4/directive/matches.hpp
@@ -65,7 +65,7 @@ struct matches_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::matches_gen matches{};
+[[maybe_unused]] inline constexpr detail::matches_gen matches{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/no_case.hpp
+++ b/include/boost/spirit/x4/directive/no_case.hpp
@@ -63,7 +63,7 @@ struct no_case_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::no_case_gen no_case{};
+[[maybe_unused]] inline constexpr detail::no_case_gen no_case{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/no_skip.hpp
+++ b/include/boost/spirit/x4/directive/no_skip.hpp
@@ -88,7 +88,7 @@ struct no_skip_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::no_skip_gen no_skip{};
+[[maybe_unused]] inline constexpr detail::no_skip_gen no_skip{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/raw.hpp
+++ b/include/boost/spirit/x4/directive/raw.hpp
@@ -81,7 +81,7 @@ struct raw_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::raw_gen raw{};
+[[maybe_unused]] inline constexpr detail::raw_gen raw{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/repeat.hpp
+++ b/include/boost/spirit/x4/directive/repeat.hpp
@@ -74,11 +74,11 @@ concept RepeatBounds = requires(std::remove_cvref_t<Bounds> const& bounds) {
 inline namespace cpos {
 
 // Infinite loop tag type
-[[deprecated("Use `x4::repeat_inf`")]]
+[[maybe_unused, deprecated("Use `x4::repeat_inf`")]]
 inline constexpr detail::repeat_inf_type inf{};
 
 // Infinite loop tag type
-inline constexpr detail::repeat_inf_type repeat_inf{};
+[[maybe_unused]] inline constexpr detail::repeat_inf_type repeat_inf{};
 
 } // cpos
 
@@ -188,7 +188,7 @@ struct repeat_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::repeat_gen repeat{};
+[[maybe_unused]] inline constexpr detail::repeat_gen repeat{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/seek.hpp
+++ b/include/boost/spirit/x4/directive/seek.hpp
@@ -65,7 +65,7 @@ struct seek_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::seek_gen seek{};
+[[maybe_unused]] inline constexpr detail::seek_gen seek{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/skip.hpp
+++ b/include/boost/spirit/x4/directive/skip.hpp
@@ -179,8 +179,8 @@ struct reskip_gen
 
 namespace parsers::directive {
 
-inline constexpr detail::skip_gen skip{};
-inline constexpr detail::reskip_gen reskip{};
+[[maybe_unused]] inline constexpr detail::skip_gen skip{};
+[[maybe_unused]] inline constexpr detail::reskip_gen reskip{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/directive/with.hpp
+++ b/include/boost/spirit/x4/directive/with.hpp
@@ -215,7 +215,7 @@ namespace parsers::directive {
 // `with` directive injects a value into the context prior to parsing.
 // Holds lvalue references by reference, holds rvalue reference by value.
 template<class ID>
-inline constexpr detail::with_fn<ID> with{};
+[[maybe_unused]] inline constexpr detail::with_fn<ID> with{};
 
 } // parsers::directive
 

--- a/include/boost/spirit/x4/numeric/bool.hpp
+++ b/include/boost/spirit/x4/numeric/bool.hpp
@@ -190,9 +190,9 @@ private:
 
 namespace standard {
 
-inline constexpr bool_parser<bool, char_encoding::standard> bool_{};
-inline constexpr literal_bool_parser<bool, char_encoding::standard> true_{true};
-inline constexpr literal_bool_parser<bool, char_encoding::standard> false_{false};
+[[maybe_unused]] inline constexpr bool_parser<bool, char_encoding::standard> bool_{};
+[[maybe_unused]] inline constexpr literal_bool_parser<bool, char_encoding::standard> true_{true};
+[[maybe_unused]] inline constexpr literal_bool_parser<bool, char_encoding::standard> false_{false};
 
 } // standard
 
@@ -207,9 +207,9 @@ using x4::standard::false_;
 #ifndef BOOST_SPIRIT_X4_NO_STANDARD_WIDE
 namespace standard_wide {
 
-inline constexpr bool_parser<bool, char_encoding::standard_wide> bool_{};
-inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> true_{true};
-inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> false_{false};
+[[maybe_unused]] inline constexpr bool_parser<bool, char_encoding::standard_wide> bool_{};
+[[maybe_unused]] inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> true_{true};
+[[maybe_unused]] inline constexpr literal_bool_parser<bool, char_encoding::standard_wide> false_{false};
 
 } // standard_wide
 

--- a/include/boost/spirit/x4/numeric/int.hpp
+++ b/include/boost/spirit/x4/numeric/int.hpp
@@ -52,15 +52,15 @@ struct int_parser : parser<int_parser<T, Radix, MinDigits, MaxDigits>>
 
 namespace parsers {
 
-inline constexpr int_parser<short> short_{};
-inline constexpr int_parser<int> int_{};
-inline constexpr int_parser<long> long_{};
-inline constexpr int_parser<long long> long_long{};
+[[maybe_unused]] inline constexpr int_parser<short> short_{};
+[[maybe_unused]] inline constexpr int_parser<int> int_{};
+[[maybe_unused]] inline constexpr int_parser<long> long_{};
+[[maybe_unused]] inline constexpr int_parser<long long> long_long{};
 
-inline constexpr int_parser<std::int8_t> int8{};
-inline constexpr int_parser<std::int16_t> int16{};
-inline constexpr int_parser<std::int32_t> int32{};
-inline constexpr int_parser<std::int64_t> int64{};
+[[maybe_unused]] inline constexpr int_parser<std::int8_t> int8{};
+[[maybe_unused]] inline constexpr int_parser<std::int16_t> int16{};
+[[maybe_unused]] inline constexpr int_parser<std::int32_t> int32{};
+[[maybe_unused]] inline constexpr int_parser<std::int64_t> int64{};
 
 } // parsers
 

--- a/include/boost/spirit/x4/numeric/real.hpp
+++ b/include/boost/spirit/x4/numeric/real.hpp
@@ -254,9 +254,9 @@ struct real_parser : parser<real_parser<T, Policy>>
 
 namespace parsers {
 
-inline constexpr real_parser<float> float_{};
-inline constexpr real_parser<double> double_{};
-inline constexpr real_parser<long double> long_double{};
+[[maybe_unused]] inline constexpr real_parser<float> float_{};
+[[maybe_unused]] inline constexpr real_parser<double> double_{};
+[[maybe_unused]] inline constexpr real_parser<long double> long_double{};
 
 } // parsers
 

--- a/include/boost/spirit/x4/numeric/uint.hpp
+++ b/include/boost/spirit/x4/numeric/uint.hpp
@@ -51,19 +51,19 @@ struct uint_parser : parser<uint_parser<T, Radix, MinDigits, MaxDigits>>
 
 namespace parsers {
 
-inline constexpr uint_parser<unsigned short> ushort_{};
-inline constexpr uint_parser<unsigned int> uint_{};
-inline constexpr uint_parser<unsigned long> ulong_{};
-inline constexpr uint_parser<unsigned long long> ulong_long{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned short> ushort_{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned int> uint_{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned long> ulong_{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned long long> ulong_long{};
 
-inline constexpr uint_parser<std::uint8_t> uint8{};
-inline constexpr uint_parser<std::uint16_t> uint16{};
-inline constexpr uint_parser<std::uint32_t> uint32{};
-inline constexpr uint_parser<std::uint64_t> uint64{};
+[[maybe_unused]] inline constexpr uint_parser<std::uint8_t> uint8{};
+[[maybe_unused]] inline constexpr uint_parser<std::uint16_t> uint16{};
+[[maybe_unused]] inline constexpr uint_parser<std::uint32_t> uint32{};
+[[maybe_unused]] inline constexpr uint_parser<std::uint64_t> uint64{};
 
-inline constexpr uint_parser<unsigned, 2> bin{};
-inline constexpr uint_parser<unsigned, 8> oct{};
-inline constexpr uint_parser<unsigned, 16> hex{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned, 2> bin{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned, 8> oct{};
+[[maybe_unused]] inline constexpr uint_parser<unsigned, 16> hex{};
 
 } // parsers
 

--- a/include/boost/spirit/x4/parse.hpp
+++ b/include/boost/spirit/x4/parse.hpp
@@ -382,7 +382,7 @@ struct parse_fn : parse_fn_main, parse_fn_deprecated
 
 inline namespace cpos {
 
-inline constexpr detail::parse_fn parse{};
+[[maybe_unused]] inline constexpr detail::parse_fn parse{};
 
 [[maybe_unused, deprecated("Use `parse(...)`. Spirit can now dispatch overloads correctly.")]]
 inline constexpr detail::parse_fn phrase_parse{};

--- a/include/boost/spirit/x4/string/case_compare.hpp
+++ b/include/boost/spirit/x4/string/case_compare.hpp
@@ -114,7 +114,7 @@ struct case_compare_tag
 };
 
 struct case_compare_no_case_t {};
-inline constexpr case_compare_no_case_t case_compare_no_case{};
+[[maybe_unused]] inline constexpr case_compare_no_case_t case_compare_no_case{};
 
 } // detail
 

--- a/include/boost/spirit/x4/traits/container_traits.hpp
+++ b/include/boost/spirit/x4/traits/container_traits.hpp
@@ -179,7 +179,7 @@ struct push_back_fn
 
 inline namespace cpos {
 
-inline constexpr detail::push_back_fn push_back{};
+[[maybe_unused]] inline constexpr detail::push_back_fn push_back{};
 
 } // cpos
 
@@ -238,7 +238,7 @@ struct append_fn
 
 inline namespace cpos {
 
-inline constexpr detail::append_fn append{};
+[[maybe_unused]] inline constexpr detail::append_fn append{};
 
 } // cpos
 
@@ -283,7 +283,7 @@ struct clear_fn
 
 inline namespace cpos {
 
-inline constexpr detail::clear_fn clear{};
+[[maybe_unused]] inline constexpr detail::clear_fn clear{};
 
 } // cpos
 
@@ -326,7 +326,7 @@ struct is_empty_fn
 
 inline namespace cpos {
 
-inline constexpr detail::is_empty_fn is_empty{};
+[[maybe_unused]] inline constexpr detail::is_empty_fn is_empty{};
 
 } // cpos
 
@@ -368,7 +368,7 @@ struct begin_fn
 
 inline namespace cpos {
 
-inline constexpr detail::begin_fn begin{};
+[[maybe_unused]] inline constexpr detail::begin_fn begin{};
 
 } // cpos
 
@@ -409,7 +409,7 @@ struct end_fn
 
 inline namespace cpos {
 
-inline constexpr detail::end_fn end{};
+[[maybe_unused]] inline constexpr detail::end_fn end{};
 
 } // cpos
 

--- a/test/x4/test.hpp
+++ b/test/x4/test.hpp
@@ -121,7 +121,7 @@ struct parse_overloads : x4::detail::parse_fn_main
 
 inline namespace cpos {
 
-inline constexpr detail::parse_overloads parse{};
+[[maybe_unused]] inline constexpr detail::parse_overloads parse{};
 
 } // cpos
 

--- a/workbench/unicode/create_tables.cpp
+++ b/workbench/unicode/create_tables.cpp
@@ -591,7 +591,7 @@ void print_file(Out& out, Builder& builder, int field_width, char const* name)
 
     out
         << "\n"
-        << "    inline constexpr std::uint8_t " << name << "_stage1[] = {\n"
+        << "    [[maybe_unused]] inline constexpr std::uint8_t " << name << "_stage1[] = {\n"
         << "\n"
         ;
 
@@ -603,7 +603,7 @@ void print_file(Out& out, Builder& builder, int field_width, char const* name)
         << "    };"
         << "\n"
         << "\n"
-        << "    inline constexpr " << int_name << ' ' << name << "_stage2[] = {"
+        << "    [[maybe_unused]] inline constexpr " << int_name << ' ' << name << "_stage2[] = {"
         ;
 
     int block_n = 0;


### PR DESCRIPTION
Part of #1 
Follow-up for #68 and potentially many other PRs

Many inline variables, notably `inline constexpr` CPOs were introduced since the beginning of the C++23 modernization. GCC tends to report false-positive "unused variable" warnings for such entities. It has been problematic because the warnings were shown in a very unpredictable scenario; even I made sure no warnings were shown in the initial PR, the warnings were showing up after some irrelevant PRs were merged.

This PR proactively adds `[[maybe_unused]]` to all inline variables to prevent further bogus warnings.