### PR TITLE
Remove `_where` context

### DIFF
--- a/include/boost/spirit/x4/core/action.hpp
+++ b/include/boost/spirit/x4/core/action.hpp
@@ -25,35 +25,19 @@ namespace detail {
 
 struct raw_attribute_t;
 
-// Compose attr(where(val(context)))
-template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
-struct action_context_impl;
+template<class Context, X4Attribute Attr>
+struct action_context;
 
-template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
-using action_context_t = typename action_context_impl<It, Se, Context, Attr>::type;
-
-template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4NonUnusedAttribute Attr>
-struct action_context_impl<It, Se, Context, Attr>
+template<class Context, X4NonUnusedAttribute Attr>
+struct action_context<Context, Attr>
 {
-    using type = context<
-        contexts::attr,
-        Attr,
-        context<
-            contexts::where,
-            std::ranges::subrange<It, Se> const,
-            canonical_context_t<Context const&>
-        >
-    >;
+    using type = context<contexts::attr, Attr, canonical_context_t<Context const&>>;
 };
 
-template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4UnusedAttribute Attr>
-struct action_context_impl<It, Se, Context, Attr>
+template<class Context, X4UnusedAttribute Attr>
+struct action_context<Context, Attr>
 {
-    using type = context<
-        contexts::where,
-        std::ranges::subrange<It, Se> const,
-        canonical_context_t<Context const&>
-    >;
+    using type = Context const&;
 };
 
 } // detail
@@ -72,11 +56,11 @@ struct action_context_impl<It, Se, Context, Attr>
 // operates on user-specific precondition that assumes the context
 // holds exact specific type provided to the entry point (`x4::parse`).
 
-template<class Subject, class Action>
-struct action : proxy_parser<Subject, action<Subject, Action>>
+template<class Subject, class ActionF>
+struct action : proxy_parser<Subject, action<Subject, ActionF>>
 {
     static_assert(
-        !std::is_reference_v<Action>,
+        !std::is_reference_v<ActionF>,
         "Reference type is disallowed for semantic action functor to prevent dangling reference"
     );
 
@@ -85,12 +69,12 @@ struct action : proxy_parser<Subject, action<Subject, Action>>
     static constexpr bool has_action = true;
     static constexpr bool need_rcontext = true;
 
-    Action f;
+    ActionF f;
 
     template<class SubjectT, class ActionT>
-        requires std::is_constructible_v<base_type, SubjectT> && std::is_constructible_v<Action, ActionT>
+        requires std::is_constructible_v<base_type, SubjectT> && std::is_constructible_v<ActionF, ActionT>
     constexpr action(SubjectT&& subject, ActionT&& f)
-        noexcept(std::is_nothrow_constructible_v<base_type, SubjectT> && std::is_nothrow_constructible_v<Action, ActionT>)
+        noexcept(std::is_nothrow_constructible_v<base_type, SubjectT> && std::is_nothrow_constructible_v<ActionF, ActionT>)
         : base_type(std::forward<SubjectT>(subject))
         , f(std::forward<ActionT>(f))
     {
@@ -122,86 +106,22 @@ struct action : proxy_parser<Subject, action<Subject, Action>>
     constexpr void operator[](auto const&) const = delete; // You can't add semantic action for semantic action
 
 private:
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
-        requires std::invocable<Action const&, detail::action_context_t<It, Se, Context, Attr> const&>
+    // Semantic action with no parameter: `p[([] { /* ... */ })]`
+    template<class Context, X4Attribute Attr>
     [[nodiscard]] constexpr bool
-    call_action(
-        It& first, Se const& last,
-        Context const& ctx, Attr& attr
-    ) const noexcept(false) // construction of `subrange` is never noexcept as per the standard
-    {
-        using action_return_type = std::invoke_result_t<Action const&, detail::action_context_t<It, Se, Context, Attr> const&>;
-        constexpr bool action_returns_bool = std::same_as<action_return_type, bool>;
-        static_assert(
-            action_returns_bool || std::same_as<action_return_type, void>,
-            "Semantic action should not return value other than `bool`. Check your function signature."
-        );
-
-        // TODO:
-        // Provide some trait to detect whether this is actually needed for
-        // each semantic actions.
-        //
-        // Although this can be assumed to be eliminated in optimized code,
-        // this still may introduce compile time overhead (and also runtime
-        // overhead, as constructing `subrange` is never noexcept).
-        std::ranges::subrange<It, Se> const where_rng(first, last);
-
-        // Inject `_attr` only when `Attr` is not `unused_type`
-        if constexpr (X4UnusedAttribute<Attr>) {
-            auto const where_ctx = x4::make_context<contexts::where>(where_rng, ctx);
-
-            // Sanity check (internal check for detecting implementation divergence)
-            static_assert(std::same_as<
-                std::remove_const_t<decltype(where_ctx)>,
-                detail::action_context_t<It, Se, Context, Attr>
-            >);
-
-            if constexpr (action_returns_bool) {
-                return this->f(where_ctx);
-            } else {
-                this->f(where_ctx);
-                return true;
-            }
-
-        } else {
-            auto const attr_ctx = x4::make_context<contexts::attr>(
-                attr,
-                x4::make_context<contexts::where>(where_rng, ctx)
-            );
-
-            // Sanity check (internal check for detecting implementation divergence)
-            static_assert(std::same_as<
-                std::remove_const_t<decltype(attr_ctx)>,
-                detail::action_context_t<It, Se, Context, Attr>
-            >);
-
-            if constexpr (action_returns_bool) {
-                return this->f(attr_ctx);
-            } else {
-                this->f(attr_ctx);
-                return true;
-            }
-        }
-    }
-
-    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
-        requires (!std::invocable<Action const&, detail::action_context_t<It, Se, Context, Attr> const&>)
-    [[nodiscard]] constexpr bool
-    call_action(
-        It&, Se const&,
-        Context const&, Attr&
-    ) const noexcept(std::is_nothrow_invocable_v<Action const&>)
+    call_action(Context const&, Attr&) const
+        noexcept(std::is_nothrow_invocable_v<ActionF const&>)
     {
         // Explicitly make this hard error instead of emitting "no matching overload".
         // This provides much more human-friendly errors.
         static_assert(
-            std::invocable<Action const&>,
+            std::invocable<ActionF const&>,
             "Neither `f(ctx)` nor `f()` is well-formed for your semantic action. "
             "Check your function signature. Note that some functors might need "
             "`const` qualifier to satisfy the constraints."
         );
 
-        using action_return_type = std::invoke_result_t<Action const&>;
+        using action_return_type = std::invoke_result_t<ActionF const&>;
         constexpr bool action_returns_bool = std::same_as<action_return_type, bool>;
         static_assert(
             action_returns_bool || std::same_as<action_return_type, void>,
@@ -216,20 +136,66 @@ private:
         }
     }
 
+    // Semantic action with parameter: `p[([](auto&& ctx) { /* ... */ })]`
+    template<class Context, X4Attribute Attr>
+        requires std::invocable<ActionF const&, typename detail::action_context<Context, Attr>::type>
+    [[nodiscard]] constexpr bool
+    call_action(Context const& ctx, Attr& attr) const
+        noexcept(std::is_nothrow_invocable_v<ActionF const&, typename detail::action_context<Context, Attr>::type>)
+    {
+        using action_return_type = std::invoke_result_t<ActionF const&, typename detail::action_context<Context, Attr>::type>;
+        constexpr bool action_returns_bool = std::same_as<action_return_type, bool>;
+        static_assert(
+            action_returns_bool || std::same_as<action_return_type, void>,
+            "Semantic action should not return value other than `bool`. Check your function signature."
+        );
+
+        // Inject `_attr` only when `Attr` is not `unused_type`
+        if constexpr (X4UnusedAttribute<Attr>) {
+            if constexpr (action_returns_bool) {
+                return this->f(ctx);
+            } else {
+                this->f(ctx);
+                return true;
+            }
+
+        } else {
+            if constexpr (action_returns_bool) {
+                return this->f(x4::make_context<contexts::attr>(attr, ctx));
+            } else {
+                this->f(x4::make_context<contexts::attr>(attr, ctx));
+                return true;
+            }
+        }
+    }
+
+    template<class Context, X4Attribute Attr>
+        requires
+            (!std::invocable<ActionF const&, typename detail::action_context<Context, Attr>::type>) &&
+            std::invocable<ActionF const&, typename detail::action_context<Context, Attr>::type const&>
+    static constexpr bool
+    call_action(Context const&, Attr&)
+    {
+        static_assert(
+            std::invocable<ActionF const&, typename detail::action_context<Context, Attr>::type>,
+            "Semantic action expecting non-const lvalue reference context is obsolete. Use `auto&& ctx` and avoid using `auto& ctx`."
+        );
+        return false; // dummy
+    }
+
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
     [[nodiscard]] constexpr bool
-    parse_main(
-        It& first, Se const& last, Context const& ctx, Attr& attr
-    ) const noexcept(
-        std::is_copy_assignable_v<It> &&
-        is_nothrow_parsable_v<Subject, It, Se, Context, Attr> &&
-        noexcept(this->call_action(first, last, ctx, attr))
-    )
+    parse_main(It& first, Se const& last, Context const& ctx, Attr& attr) const
+        noexcept(
+            std::is_copy_assignable_v<It> &&
+            is_nothrow_parsable_v<Subject, It, Se, Context, Attr> &&
+            noexcept(this->call_action(ctx, attr))
+        )
     {
         It const saved_first = first;
         if (!this->subject.parse(first, last, ctx, attr)) return false;
 
-        if (this->call_action(first, last, ctx, attr)) {
+        if (this->call_action(ctx, attr)) {
             return true;
         }
         // reset iterators if semantic action failed the match

--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -34,12 +34,6 @@ struct as_val
     static constexpr bool is_unique = true;
 };
 
-// _where
-struct where
-{
-    static constexpr bool is_unique = true;
-};
-
 // _attr
 struct attr
 {
@@ -49,7 +43,6 @@ struct attr
 } // contexts
 
 using rule_val_context_tag [[deprecated("Use `x4::contexts::rule_val`")]] = contexts::rule_val;
-using where_context_tag [[deprecated("Use `x4::contexts::where`")]] = contexts::where;
 using attr_context_tag [[deprecated("Use `x4::contexts::attr`")]] = contexts::attr;
 
 
@@ -91,14 +84,8 @@ struct _as_val_fn
 struct _where_fn
 {
     template<class Context>
-    [[nodiscard]] static constexpr auto&&
-    operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
-    {
-        return x4::get<contexts::where>(ctx);
-    }
-
-    template<class Context>
-    static void operator()(Context const&&) = delete; // dangling
+    static constexpr void
+    operator()(Context const&) = delete; // `_where` is obsolete. Use `raw[...]` directive.
 };
 
 struct _attr_fn

--- a/test/x4/actions.cpp
+++ b/test/x4/actions.cpp
@@ -22,15 +22,15 @@ TEST_CASE("action")
 
     {
         int x = 0;
-        auto const fun_action = [&](auto& ctx) { x += x4::_attr(ctx); };
+        auto const fun_action = [&](auto&& ctx) { x += x4::_attr(ctx); };
         CHECK(parse("{42}", '{' >> int_[fun_action] >> '}'));
     }
     {
-        auto const fail = [](auto&) { return false; };
+        auto const fail = [](auto&&) { return false; };
         std::string input("1234 6543");
         char next = '\0';
 
-        auto const setnext = [&](auto& ctx) {
+        auto const setnext = [&](auto&& ctx) {
             next = x4::_attr(ctx);
         };
 

--- a/test/x4/as.cpp
+++ b/test/x4/as.cpp
@@ -165,11 +165,11 @@ TEST_CASE("as")
 
         constexpr auto string_rule = x4::rule<struct _, decltype(result)>{""} =
             x4::as<std::string>(
-                eps[([](auto& ctx) {
+                eps[([](auto&& ctx) {
                     _val(ctx) = "default";
                 })] >>
 
-                eps[([](auto& ctx) {
+                eps[([](auto&& ctx) {
                     _as_val(ctx) = "foo";
                 })]
             );
@@ -187,11 +187,11 @@ TEST_CASE("as")
 
         constexpr auto string_rule = x4::rule<struct _, decltype(result)>{""} =
             x4::as<std::string>(
-                eps[([](auto& ctx) {
+                eps[([](auto&& ctx) {
                     _val(ctx) = "default";
                 })] >>
 
-                eps[([]([[maybe_unused]] auto& ctx) {
+                eps[([]([[maybe_unused]] auto&& ctx) {
                     static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
                 })]
             ) >> disable_attr; // <----------
@@ -209,7 +209,7 @@ TEST_CASE("as")
 
         constexpr auto unused_rule = x4::as<unused_type>(
             x4::as<std::string>(
-                eps[([]([[maybe_unused]] auto& ctx) {
+                eps[([]([[maybe_unused]] auto&& ctx) {
                     static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
                 })]
             )
@@ -229,12 +229,12 @@ TEST_CASE("as")
         /*constexpr*/ auto unused_rule = x4::as<std::string>(
             x4::attr("default") >>
 
-            eps[([]([[maybe_unused]] auto& ctx) {
+            eps[([]([[maybe_unused]] auto&& ctx) {
                 static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, std::string>);
             })] >>
 
             x4::as<unused_type>(
-                eps[([]([[maybe_unused]] auto& ctx) {
+                eps[([]([[maybe_unused]] auto&& ctx) {
                     static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
                 })]
             )
@@ -261,13 +261,13 @@ TEST_CASE("as")
         constexpr auto string_literal = x4::rule<struct _, StringLiteral>{"StringLiteral"} =
             eps[([](auto& ctx) { _val(ctx).is_quoted = false; })] >>
             x4::as<std::string>(
-                x4::lit('"')[([](auto& ctx) {
+                x4::lit('"')[([](auto&& ctx) {
                     StringLiteral& rule_val = _val(ctx);
                     rule_val.is_quoted = true;
                 })] >>
                 *~x4::char_('"') >>
                 '"'
-            )[([](auto& ctx) { _val(ctx).text = std::move(_attr(ctx)); })];
+            )[([](auto&& ctx) { _val(ctx).text = std::move(_attr(ctx)); })];
 
         std::string_view input = R"("foo")";
         It first = input.begin();

--- a/test/x4/char_class.cpp
+++ b/test/x4/char_class.cpp
@@ -196,7 +196,7 @@ TEST_CASE("char_class")
         using namespace x4::standard;
         using x4::_attr;
         char ch = '\0';
-        auto f = [&](auto& ctx){ ch = _attr(ctx); };
+        auto f = [&](auto&& ctx){ ch = _attr(ctx); };
 
         REQUIRE(parse("x", alnum[f]));
         CHECK(ch == 'x');

--- a/test/x4/difference.cpp
+++ b/test/x4/difference.cpp
@@ -52,7 +52,7 @@ TEST_CASE("difference")
         std::string s;
         REQUIRE(parse(
             "/*abcdefghijk*/",
-            "/*" >> *(char_ - "*/")[([&](auto& ctx){ s += _attr(ctx); })] >> "*/"
+            "/*" >> *(char_ - "*/")[([&](auto&& ctx){ s += _attr(ctx); })] >> "*/"
         ));
         CHECK(s == "abcdefghijk");
     }
@@ -60,7 +60,7 @@ TEST_CASE("difference")
         std::string s;
         REQUIRE(parse(
             "    /*abcdefghijk*/",
-            "/*" >> *(char_ - "*/")[([&](auto& ctx){ s += _attr(ctx); })] >> "*/",
+            "/*" >> *(char_ - "*/")[([&](auto&& ctx){ s += _attr(ctx); })] >> "*/",
             space
         ));
         CHECK(s == "abcdefghijk");

--- a/test/x4/int.cpp
+++ b/test/x4/int.cpp
@@ -211,7 +211,7 @@ TEST_CASE("int")
         using x4::standard::space;
         int n = 0, m = 0;
 
-        auto f = [&](auto& ctx){ n = _attr(ctx); };
+        auto f = [&](auto&& ctx){ n = _attr(ctx); };
 
         REQUIRE(parse("123", int_[f]));
         CHECK(n == 123);

--- a/test/x4/iterator.cpp
+++ b/test/x4/iterator.cpp
@@ -214,14 +214,14 @@ TEST_CASE("rollback on failed parse (action)")
     {
         constexpr auto input = "foo"sv;
         auto first = input.begin();
-        REQUIRE_FALSE(eps[([](auto&) { return false; })].parse(first, input.end(), unused, unused));
+        REQUIRE_FALSE(eps[([](auto&&) { return false; })].parse(first, input.end(), unused, unused));
         CHECK(first == input.begin());
     }
     {
         constexpr auto input = "42"sv;
         auto first = input.begin();
         int dummy_int = -1;
-        REQUIRE_FALSE(int_[([](auto&) { return false; })].parse(first, input.end(), unused, dummy_int));
+        REQUIRE_FALSE(int_[([](auto&&) { return false; })].parse(first, input.end(), unused, dummy_int));
         CHECK(first == input.begin());
         CHECK(dummy_int == 42); // sequence parser itself succeeds; always results in side effect
     }
@@ -229,7 +229,7 @@ TEST_CASE("rollback on failed parse (action)")
         constexpr auto input = "42,43"sv;
         auto first = input.begin();
         std::vector<int> dummy_ints;
-        REQUIRE_FALSE((int_ >> ',' >> int_)[([](auto&) { return false; })].parse(first, input.end(), unused, dummy_ints));
+        REQUIRE_FALSE((int_ >> ',' >> int_)[([](auto&&) { return false; })].parse(first, input.end(), unused, dummy_ints));
         CHECK(first == input.begin());
         CHECK(dummy_ints == std::vector<int>{42, 43}); // sequence parser itself succeeds; always results in side effect
     }

--- a/test/x4/kleene.cpp
+++ b/test/x4/kleene.cpp
@@ -105,7 +105,7 @@ TEST_CASE("kleene")
         using x4::_attr;
 
         std::string v;
-        auto f = [&](auto& ctx){ v = _attr(ctx); };
+        auto f = [&](auto&& ctx){ v = _attr(ctx); };
 
         REQUIRE(parse("bbbb", (*char_)[f]));
         REQUIRE(v.size() == 4);
@@ -120,7 +120,7 @@ TEST_CASE("kleene")
         using x4::_attr;
 
         std::vector<int> v;
-        auto f = [&](auto& ctx){ v = _attr(ctx); };
+        auto f = [&](auto&& ctx){ v = _attr(ctx); };
 
         REQUIRE(parse("123 456 789", (*int_)[f], space));
         CHECK(v.size() == 3);

--- a/test/x4/list.cpp
+++ b/test/x4/list.cpp
@@ -111,7 +111,7 @@ TEST_CASE("list")
     {
         // actions
         std::string s;
-        auto f = [&](auto& ctx){ s = std::string(_attr(ctx).begin(), _attr(ctx).end()); };
+        auto f = [&](auto&& ctx){ s = std::string(_attr(ctx).begin(), _attr(ctx).end()); };
 
         REQUIRE(parse("a,b,c,d,e,f,g,h", (char_ % ',')[f]));
         CHECK(s == "abcdefgh");

--- a/test/x4/omit.cpp
+++ b/test/x4/omit.cpp
@@ -112,7 +112,7 @@ TEST_CASE("omit")
     {
         // test action with omitted attribute
         char c = 0;
-        auto f = [&](auto& ctx){ c = _attr(ctx); };
+        auto f = [&](auto&& ctx){ c = _attr(ctx); };
 
         REQUIRE(parse("x123\"a string\"", (char_ >> omit[int_] >> "\"a string\"")[f]));
         CHECK(c == 'x');
@@ -121,7 +121,7 @@ TEST_CASE("omit")
     {
         // test action with omitted attribute
         int n = 0;
-        auto f = [&](auto& ctx){ n = _attr(ctx); };
+        auto f = [&](auto&& ctx){ n = _attr(ctx); };
 
         REQUIRE(parse("x 123 \"a string\"", (omit[char_] >> int_ >> "\"a string\"")[f], space));
         CHECK(n == 123);

--- a/test/x4/optional.cpp
+++ b/test/x4/optional.cpp
@@ -45,7 +45,7 @@ namespace {
 struct test_attribute_type
 {
     template<class Context>
-    void operator()(Context& ctx) const
+    void operator()(Context&& ctx) const
     {
         CHECK(typeid(decltype(x4::_attr(ctx))).name() == typeid(std::optional<int>).name());
     }
@@ -161,13 +161,13 @@ TEST_CASE("optional")
 
     {
         std::optional<int> n;
-        auto f = [&](auto& ctx) { n = _attr(ctx); };
+        auto f = [&](auto&& ctx) { n = _attr(ctx); };
         CHECK(parse("abcd", (-int_)[f]).is_partial_match());
         CHECK(!n.has_value());
     }
     {
         std::optional<int> n = 0;
-        auto f = [&](auto& ctx){ n = _attr(ctx); };
+        auto f = [&](auto&& ctx){ n = _attr(ctx); };
         REQUIRE(parse("1234", (-int_)[f]));
         CHECK(*n == 1234);
     }

--- a/test/x4/plus.cpp
+++ b/test/x4/plus.cpp
@@ -106,7 +106,7 @@ TEST_CASE("plus")
     {
         // actions
         std::string v;
-        auto f = [&](auto& ctx){ v = _attr(ctx); };
+        auto f = [&](auto&& ctx){ v = _attr(ctx); };
 
         REQUIRE(parse("bbb", (+char_)[f]));
         REQUIRE(v.size() == 3);
@@ -118,7 +118,7 @@ TEST_CASE("plus")
     {
         // more actions
         std::vector<int> v;
-        auto f = [&](auto& ctx){ v = _attr(ctx); };
+        auto f = [&](auto&& ctx){ v = _attr(ctx); };
 
         REQUIRE(parse("1 2 3", (+int_)[f], space));
         REQUIRE(v.size() == 3);

--- a/test/x4/raw.cpp
+++ b/test/x4/raw.cpp
@@ -83,7 +83,7 @@ TEST_CASE("raw")
 
     {
         std::ranges::subrange<std::string_view::const_iterator> range;
-        REQUIRE(parse("x", raw[alpha][ ([&](auto& ctx){ range = _attr(ctx); }) ]));
+        REQUIRE(parse("x", raw[alpha][ ([&](auto&& ctx){ range = _attr(ctx); }) ]));
         REQUIRE(range.size() == 1);
         CHECK(*range.begin() == 'x');
     }

--- a/test/x4/rule2.cpp
+++ b/test/x4/rule2.cpp
@@ -35,14 +35,14 @@ TEST_CASE("rule2")
         {
             char ch{};
             // This semantic action requires the context
-            auto f = [&](auto& ctx){ ch = _attr(ctx); };
+            auto f = [&](auto&& ctx){ ch = _attr(ctx); };
             REQUIRE(parse("x", a[f]));
             CHECK(ch == 'x');
         }
         {
             char ch{};
             // This semantic action requires the (unused) context
-            auto f2 = [&](auto&){ ch = 'y'; };
+            auto f2 = [&](auto&&){ ch = 'y'; };
             REQUIRE(parse("x", a[f2]));
             CHECK(ch == 'y');
         }
@@ -68,7 +68,7 @@ TEST_CASE("rule2")
 
         {
             char ch{};
-            auto f = [&](auto& ctx){ ch = _attr(ctx); };
+            auto f = [&](auto&& ctx){ ch = _attr(ctx); };
             REQUIRE(parse("x", a[f]));
             CHECK(ch == 'x');
         }
@@ -79,7 +79,7 @@ TEST_CASE("rule2")
         }
         {
             char ch{};
-            auto f = [&](auto& ctx) { ch = _attr(ctx); };
+            auto f = [&](auto&& ctx) { ch = _attr(ctx); };
             REQUIRE(parse("x", a[f]));
             CHECK(ch == 'x');
         }
@@ -99,7 +99,7 @@ TEST_CASE("rule2")
         constexpr auto r = rule<class r_id, std::string>("r") = char_ >> *(',' >> char_);
 
         std::string s;
-        auto f = [&](auto& ctx) { s = _attr(ctx); };
+        auto f = [&](auto&& ctx) { s = _attr(ctx); };
         REQUIRE(parse("a,b,c,d,e,f", r[f]));
         CHECK(s == "abcdef");
     }
@@ -107,7 +107,7 @@ TEST_CASE("rule2")
         constexpr auto r = rule<class r_id, std::string>("r") = char_ >> *(',' >> char_);
 
         std::string s;
-        auto f = [&](auto& ctx) { s = _attr(ctx); };
+        auto f = [&](auto&& ctx) { s = _attr(ctx); };
         REQUIRE(parse("a,b,c,d,e,f", r[f]));
         CHECK(s == "abcdef");
     }
@@ -115,7 +115,7 @@ TEST_CASE("rule2")
         auto r = rule<class r_id, std::string>("r") = char_ >> char_ >> char_ >> char_ >> char_ >> char_;
 
         std::string s;
-        auto f = [&](auto& ctx) { s = _attr(ctx); };
+        auto f = [&](auto&& ctx) { s = _attr(ctx); };
         REQUIRE(parse("abcdef", r[f]));
         CHECK(s == "abcdef");
     }

--- a/test/x4/rule3.cpp
+++ b/test/x4/rule3.cpp
@@ -104,7 +104,7 @@ TEST_CASE("rule3")
         std::string s;
         using rule_type = rule<class r, std::string>;
 
-        auto rdef = rule_type{} = alpha[([](auto& ctx) {
+        auto rdef = rule_type{} = alpha[([](auto&& ctx) {
             x4::_val(ctx) += x4::_attr(ctx);
         })];
 
@@ -118,7 +118,7 @@ TEST_CASE("rule3")
         using rule_type = rule<class r, std::string>;
 
         auto rdef = rule_type() =
-            alpha[([](auto& ctx) {
+            alpha[([](auto&& ctx) {
                 _val(ctx) += _attr(ctx);
             })];
 
@@ -127,7 +127,7 @@ TEST_CASE("rule3")
     }
 
     {
-        auto r = rule<class r_id, int>{} = eps[([] ([[maybe_unused]] auto& ctx) {
+        auto r = rule<class r_id, int>{} = eps[([] ([[maybe_unused]] auto&& ctx) {
             static_assert(
                 std::is_same_v<std::decay_t<decltype(_val(ctx))>, unused_type>,
                 "Attr must not be synthesized"

--- a/test/x4/rule4.cpp
+++ b/test/x4/rule4.cpp
@@ -102,7 +102,7 @@ TEST_CASE("rule4")
         rule<class a, int> ra;
         rule<class b, int> rb;
         (void)rb;
-        auto f = [](auto&) {};
+        auto f = [](auto&&) {};
         auto ra_def = ra %= int_[f];
         auto ra_def2 = (rb = (ra %= int_[f]));
 

--- a/test/x4/sequence.cpp
+++ b/test/x4/sequence.cpp
@@ -414,7 +414,7 @@ TEST_CASE("sequence")
 
         char c = 0;
         int n = 0;
-        auto f = [&](auto& ctx) {
+        auto f = [&](auto&& ctx) {
             c = at_c<0>(_attr(ctx));
             n = at_c<1>(_attr(ctx));
         };
@@ -428,7 +428,7 @@ TEST_CASE("sequence")
         // test action
         char c = 0;
         int n = 0;
-        auto f = [&](auto& ctx) {
+        auto f = [&](auto&& ctx) {
             c = at_c<0>(_attr(ctx));
             n = at_c<1>(_attr(ctx));
         };

--- a/test/x4/symbols1.cpp
+++ b/test/x4/symbols1.cpp
@@ -156,7 +156,7 @@ TEST_CASE("symbols1")
         ;
 
         int i = 0;
-        auto f = [&](auto& ctx){ i = _attr(ctx); }; // lambda with capture (important for subsequent checks)
+        auto f = [&](auto&& ctx){ i = _attr(ctx); }; // lambda with capture (important for subsequent checks)
 
         using Parser = std::remove_cvref_t<decltype(sym[f])>;
         STATIC_CHECK(x4::X4ExplicitSubject<Parser>);

--- a/test/x4/uint.cpp
+++ b/test/x4/uint.cpp
@@ -201,7 +201,7 @@ TEST_CASE("uint")
         using x4::standard::space;
 
         int n = 0;
-        auto f = [&](auto& ctx){ n = _attr(ctx); };
+        auto f = [&](auto&& ctx){ n = _attr(ctx); };
 
         REQUIRE(parse("123", uint_[f]));
         CHECK(n == 123);


### PR DESCRIPTION
Part of #1 

According to the GitHub full text search, `x3::_where` has almost zero use case. We simply remove it now.

Additionally, the old codebase allowed semantic action to be defined in a form like `[](auto& ctx) { /* ... */}`, which chokes on prvalue context. If we keep that behavior, we must always create a local context variable just for _inventing_ lvalue reference. As a resolution, this PR prohibits lvalue-only functor definition in the first place and guides users to define `[](auto&& ctx) { /* ... */ }` instead.

The removal of `_where` context and the temporary context variable results in complete elimination of unused references created by the core parsers, finalizing our context-related optimization in X4.