### PR TITLE
Implement `x4::with_local<T>[...]` and `x4::with_local<T, ID>[...]`

### DIFF
--- a/include/boost/spirit/x4/directive.hpp
+++ b/include/boost/spirit/x4/directive.hpp
@@ -22,5 +22,6 @@
 #include <boost/spirit/x4/directive/seek.hpp>
 #include <boost/spirit/x4/directive/skip.hpp>
 #include <boost/spirit/x4/directive/with.hpp>
+#include <boost/spirit/x4/directive/with_local.hpp>
 
 #endif

--- a/include/boost/spirit/x4/directive/with_local.hpp
+++ b/include/boost/spirit/x4/directive/with_local.hpp
@@ -1,0 +1,105 @@
+﻿#ifndef BOOST_SPIRIT_X4_DIRECTIVE_WITH_LOCAL_HPP
+#define BOOST_SPIRIT_X4_DIRECTIVE_WITH_LOCAL_HPP
+
+#include <boost/spirit/x4/core/parser.hpp>
+#include <boost/spirit/x4/core/context.hpp>
+
+#include <concepts>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace boost::spirit::x4 {
+
+namespace contexts {
+
+// Points to the innermost local variable created by
+// `x4::with_local<T>[...]` directive.
+//
+// - If you need multiple local variables, use `std::tuple<...>` for `T`.
+// - If you need distinct local variables in a nested grammar structure,
+//   don't use `x4::local_var`; use your own context tag type.
+struct local_var
+{
+    static constexpr bool is_unique = true;
+};
+
+} // contexts
+
+namespace detail {
+
+struct local_var_fn
+{
+    template<class Context>
+    [[nodiscard]] static constexpr decltype(auto) operator()(Context const& ctx) noexcept
+    {
+        return x4::get<contexts::local_var>(ctx);
+    }
+};
+
+} // detail
+
+inline namespace cpos {
+
+[[maybe_unused]] inline constexpr detail::local_var_fn _local_var{};
+
+} // cpos
+
+
+template<class Subject, class ID, class T>
+struct with_local_directive : proxy_parser<Subject, with_local_directive<Subject, ID, T>>
+{
+    static_assert(std::default_initializable<T>);
+
+    using id_type = ID;
+    using value_type = T;
+
+    template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, X4Attribute Attr>
+    [[nodiscard]] constexpr bool
+    parse(It& first, Se const& last, Context const& ctx, Attr& attr) const
+        noexcept(
+            std::is_nothrow_default_constructible_v<T> &&
+            x4::is_nothrow_parsable_v<
+                Subject, It, Se,
+                decltype(x4::replace_first_context<ID>(ctx, std::declval<T&>())),
+                Attr
+            >
+        )
+    {
+        // `x4::make_context(...)` cannot be used here as it invokes infinite recursive instantiation.
+
+        T local_var{}; // value-initialize
+        return this->subject.parse(first, last, x4::replace_first_context<ID>(ctx, local_var), attr);
+    }
+};
+
+namespace detail {
+
+template<class ID, class T>
+struct with_local_gen
+{
+    template<class Subject>
+    [[nodiscard]] constexpr with_local_directive<std::remove_cvref_t<Subject>, ID, T>
+    operator[](Subject&& subject) const // TODO: MSVC 2022 does not properly handle static operator[]
+        noexcept(std::is_nothrow_constructible_v<with_local_directive<std::remove_cvref_t<Subject>, ID, T>, Subject>)
+    {
+        return with_local_directive<std::remove_cvref_t<Subject>, ID, T>{
+            std::forward<Subject>(subject)
+        };
+    }
+};
+
+} // detail
+
+namespace parsers::directive {
+
+template<class T, class ID = contexts::local_var>
+[[maybe_unused]] inline constexpr detail::with_local_gen<ID, T> with_local{};
+
+} // parsers::directive
+
+using parsers::directive::with_local;
+
+} // boost::spirit::x4
+
+#endif

--- a/test/x4/CMakeLists.txt
+++ b/test/x4/CMakeLists.txt
@@ -105,6 +105,7 @@ x4_define_tests(
     uint_radix
     unused
     with
+    with_local
     x3_rule_problem
 )
 

--- a/test/x4/Jamfile
+++ b/test/x4/Jamfile
@@ -94,6 +94,7 @@ run omit.cpp catch2 ;
 run optional.cpp catch2 ;
 run plus.cpp catch2 ;
 run with.cpp catch2 ;
+run with_local.cpp catch2 ;
 run as.cpp catch2 ;
 
 run raw.cpp catch2 ;

--- a/test/x4/with_local.cpp
+++ b/test/x4/with_local.cpp
@@ -1,0 +1,170 @@
+/*=============================================================================
+    Copyright (c) 2025 Nana Sakisaka
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+#include "test.hpp"
+
+#include <boost/spirit/x4/directive/with_local.hpp>
+#include <boost/spirit/x4/directive/as.hpp>
+#include <boost/spirit/x4/numeric/int.hpp>
+#include <boost/spirit/x4/auxiliary/eps.hpp>
+#include <boost/spirit/x4/operator/sequence.hpp>
+
+#include <concepts>
+#include <string_view>
+#include <tuple>
+
+#include <cmath>
+
+TEST_CASE("with_local")
+{
+    using x4::with_local;
+    using x4::as;
+    using x4::_local_var;
+    using x4::_attr;
+    using x4::_as_val;
+    using x4::int_;
+    using x4::eps;
+
+    // `as<int>` + `with_local<int>`
+    {
+        constexpr auto p = with_local<int>[
+            as<int>(
+                int_[([](auto&& ctx) {
+                    CHECK(_local_var(ctx) == 0);
+                    _local_var(ctx) = _attr(ctx) * 100;
+                })] >>
+                eps[([](auto&& ctx) {
+                    _as_val(ctx) = _local_var(ctx);
+                })]
+            )
+        ];
+        constexpr std::string_view input = "42";
+        auto first = input.begin();
+        int i = -1;
+        REQUIRE(p.parse(first, input.end(), unused, i));
+        CHECK(i == 4200);
+    }
+
+    // `with_local<int>` with semantic action assignment
+    {
+        int i = -1;
+
+        auto const p = with_local<int>[
+            int_[([](auto&& ctx) {
+                CHECK(_local_var(ctx) == 0);
+                _local_var(ctx) = _attr(ctx) * 100;
+            })] >>
+            eps[([&](auto&& ctx) {
+                i = _local_var(ctx);
+            })]
+        ];
+        constexpr std::string_view input = "42";
+        auto first = input.begin();
+        REQUIRE(p.parse(first, input.end(), unused, unused));
+        CHECK(i == 4200);
+    }
+
+    // `with_local<int>[with_local<int>[...]]`
+    {
+        int i = -1;
+
+        auto const p = with_local<int>[
+            eps[([](auto&& ctx) {
+                CHECK(_local_var(ctx) == 0);
+            })] >>
+
+            with_local<int>[
+                eps[([](auto&& ctx) {
+                    CHECK(_local_var(ctx) == 0.0);
+                })] >>
+                int_[([](auto&& ctx) {
+                    _local_var(ctx) = _attr(ctx);
+                })] >>
+                eps[([&](auto&& ctx) {
+                    i = _local_var(ctx) * 100;
+                })]
+            ] >>
+
+            eps[([](auto&& ctx) {
+                CHECK(_local_var(ctx) == 0);
+            })]
+        ];
+        constexpr std::string_view input = "42";
+        auto first = input.begin();
+        REQUIRE(p.parse(first, input.end(), unused, unused));
+        CHECK(i == 4200);
+    }
+
+    // `with_local<int>[with_local<double>[...]]`
+    {
+        double d = -1.0;
+
+        auto const p = with_local<int>[
+            eps[([](auto&& ctx) {
+                static_assert(std::same_as<decltype(_local_var(ctx)), int&>);
+                CHECK(_local_var(ctx) == 0);
+            })] >>
+
+            with_local<double>[
+                eps[([](auto&& ctx) {
+                    static_assert(std::same_as<decltype(_local_var(ctx)), double&>);
+                    CHECK(_local_var(ctx) == 0.0);
+                })] >>
+                int_[([](auto&& ctx) {
+                    _local_var(ctx) = _attr(ctx);
+                })] >>
+                eps[([&](auto&& ctx) {
+                    d = std::ceil(static_cast<double>(_local_var(ctx)) / 10);
+                })]
+            ] >>
+
+            eps[([](auto&& ctx) {
+                CHECK(_local_var(ctx) == 0);
+            })]
+        ];
+        constexpr std::string_view input = "42";
+        auto first = input.begin();
+        REQUIRE(p.parse(first, input.end(), unused, unused));
+        CHECK(d == 5);
+    }
+
+    // `with_local<int, A_ID>[with_local<int, B_ID>[...]]`
+    {
+        std::tuple<int, int> res{};
+
+        struct A_ID {};
+        struct B_ID {};
+
+        auto const p = with_local<int, A_ID>[
+            eps[([](auto&& ctx) {
+                CHECK(x4::get<A_ID>(ctx) == 0);
+            })] >>
+
+            with_local<int, B_ID>[
+                eps[([](auto&& ctx) {
+                    CHECK(x4::get<B_ID>(ctx) == 0.0);
+                })] >>
+                int_[([](auto&& ctx) {
+                    x4::get<A_ID>(ctx) = _attr(ctx) * 10;
+                    x4::get<B_ID>(ctx) = _attr(ctx) * 100;
+                })] >>
+                eps[([&](auto&& ctx) {
+                    res = std::make_tuple(x4::get<A_ID>(ctx), x4::get<B_ID>(ctx));
+                })]
+            ] >>
+
+            eps[([](auto&& ctx) {
+                CHECK(x4::get<A_ID>(ctx) == 420);
+            })]
+        ];
+        constexpr std::string_view input = "42";
+        auto first = input.begin();
+        REQUIRE(p.parse(first, input.end(), unused, unused));
+        CHECK(std::get<0>(res) == 420);
+        CHECK(std::get<1>(res) == 4200);
+    }
+}

--- a/test/x4/with_local.cpp
+++ b/test/x4/with_local.cpp
@@ -79,7 +79,7 @@ TEST_CASE("with_local")
 
             with_local<int>[
                 eps[([](auto&& ctx) {
-                    CHECK(_local_var(ctx) == 0.0);
+                    CHECK(_local_var(ctx) == 0);
                 })] >>
                 int_[([](auto&& ctx) {
                     _local_var(ctx) = _attr(ctx);
@@ -118,7 +118,7 @@ TEST_CASE("with_local")
                     _local_var(ctx) = _attr(ctx);
                 })] >>
                 eps[([&](auto&& ctx) {
-                    d = std::ceil(static_cast<double>(_local_var(ctx)) / 10);
+                    d = std::ceil(_local_var(ctx) / 10);
                 })]
             ] >>
 


### PR DESCRIPTION
Part of #1 

This PR implements `x4::with_local<T>[...]` and `x4::with_local<T, ID>[...]`, similar to that of Spirit.Qi's [`qi::locals<...>`](https://www.boost.org/doc/libs/1_89_0/libs/spirit/doc/html/spirit/qi/reference/nonterminal/rule.html).

## Naming

### `x4::locals`

This is not appropriate.

In Qi era, the name `locals` was idiomatic solely because it was an extra parameter given to the `rule` nonterminal:

```cpp
qi::rule<char const*, qi::locals<char>> r;
```
 
When it comes to X4, `x4::rule` have no place for such parameter, because X4's `rule` is a more minimalist entity that consists of only the rule's tag type and the attribute type. So it should be implemented as a _directive_. Therefore, the name "locals" is no longer appropriate and we need to choose the best name.

### `x4::local`

This is OK, but if we carefully think about its semantics then it sounds awkward because it is very vague what "local" it does point to. What I'm trying to say here is that the term "local" itself is vague, but when it's used in a _directive_, it gets increasingly weird:

```cpp
auto p = x4::local<int>[
    some_parser
];
```

What "local int" does it refer to? How can `some_parser` be relevant to some "local int"? Is the underlying parser "local int"? Does the underlying parser contain some "local int"? Is that an inner variable or an outer variable? 

We could insist that it IS a local variable similar to that of Qi, but that's a very arbitrary definition and none of the above questions can be answered clearly.

### `x4::with_local`

This is the preferred naming in this PR.

## Context design

Initially I implemented `x4::with_local<ID, T>[...]`, where the `ID` parameter is mandatory and must be supplied by the users, similar to `x4::with<ID>(var)[p]`. However, there are many use cases where only a single local variable is needed for grammar definition.

The current design is to default the `ID` type to `x4::contexts::local_var`, which refers to always the _innermost_ variable created by potentially nested invocation of `with_local` parsers. This PR also provides a convenient accessor `x4::_local_var(ctx)` that fetches the corresponding variable. In this scenario, simply `x4::with_local<T>[...]` (with `ID` param omitted) can be utilized.

For more complicated scenario, users can supply arbitrary context types: `x4::with_local<T, A_ID>[x4::with_local<U, B_ID>[...]]`. This way, any number of local variables can be defined and all of them can be fetched simultaneously by specifying corresponding tag like `x4::get<A_ID>(ctx)` or `x4::get<B_ID>(ctx)`.

## Multiple local variables in a single directive

Multiple local variables in a single directive is not supported in X4 by design.

The old feature in Qi was able to have multiple local variables specified in a single _chunk_:

```cpp
qi::rule<char const*, qi::locals<int, double, std::string>> r;
```

However this required users to access the variable using a **surrogate key**, i.e., `qi::_a`, `qi::_b`, `qi::_c`, and so on. In my experience, this was an unbearable nightmare because it was very unintuitive to correlate the sequential index within the grammar _definition_, as the real index is buried deep inside the rule's _declaration_.

If we keep that design then we would have this in X4:

```cpp
auto p = x4::with_locals<int, double, std::string>[
    some_directive[
        x4::with_locals<std::vector<float>, std::optional<std::string>, bool>[
            some_parser[([](auto&& ctx) {
                /* ??? */ a = x4::_a(ctx);
                /* ??? */ b = x4::_b(ctx);
                /* ??? */ c = x4::_c(ctx);
            })]
        ]
    ][([](auto&& ctx) {
        /* ??? */ a = x4::_a(ctx);
        /* ??? */ b = x4::_b(ctx);
        /* ??? */ c = x4::_c(ctx);
    })]
];
```

I consider this very unpractical.

As a solution we can simply supply some predefined struct with arbitrary number of elements:

```cpp
struct SomeData
{
    int i;
    double d;
    std::string s;
};

auto p = x4::with_local<SomeData>[
    eps[([](auto&& ctx) {
        auto& [i, d, s] = x4::_local_var(ctx);
    })]
];
```

This way it's much cleaner, and of course, `std::tuple<...>` can also be used for this purpose.