### PR TITLE
Rename `*_val` contexts to `*_var`

### DIFF
--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -27,9 +27,9 @@ struct rule_val
     static constexpr bool is_unique = true;
 };
 
-// _as_val
+// _as_var
 // Refers to the attribute of `x4::as<T>(...)`.
-struct as_val
+struct as_var
 {
     static constexpr bool is_unique = true;
 };
@@ -68,13 +68,13 @@ struct _val_fn
     static void operator()(Context const&&) = delete; // dangling
 };
 
-struct _as_val_fn
+struct _as_var_fn
 {
     template<class Context>
     [[nodiscard]] static constexpr auto&&
     operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
     {
-        return x4::get<contexts::as_val>(ctx);
+        return x4::get<contexts::as_var>(ctx);
     }
 
     template<class Context>
@@ -107,7 +107,7 @@ inline namespace cpos {
 
 [[maybe_unused]] inline constexpr detail::_pass_fn _pass{};
 [[maybe_unused]] inline constexpr detail::_val_fn _val{};
-[[maybe_unused]] inline constexpr detail::_as_val_fn _as_val{};
+[[maybe_unused]] inline constexpr detail::_as_var_fn _as_var{};
 [[maybe_unused]] inline constexpr detail::_where_fn _where{};
 [[maybe_unused]] inline constexpr detail::_attr_fn _attr{};
 

--- a/include/boost/spirit/x4/core/action_context.hpp
+++ b/include/boost/spirit/x4/core/action_context.hpp
@@ -16,13 +16,13 @@ namespace boost::spirit::x4 {
 
 namespace contexts {
 
-// _val
+// _rule_var
 // Refers to the attribute of `x4::rule`.
 // This always points to the *innermost* attribute for the (potentially recursive) invocation of `x4::rule`.
 // Note: we currently provide no method to obtain the outer attribute, as it is discouraged for maintainability.
 //
 // This does NOT point to the attribute variable created by `x4::as<T>(...)`.
-struct rule_val
+struct rule_var
 {
     static constexpr bool is_unique = true;
 };
@@ -42,9 +42,6 @@ struct attr
 
 } // contexts
 
-using rule_val_context_tag [[deprecated("Use `x4::contexts::rule_val`")]] = contexts::rule_val;
-using attr_context_tag [[deprecated("Use `x4::contexts::attr`")]] = contexts::attr;
-
 
 namespace detail {
 
@@ -55,13 +52,13 @@ struct _pass_fn
     operator()(Context const&) = delete; // `_pass(ctx)` is obsolete. Just return bool from semantic action.
 };
 
-struct _val_fn
+struct _rule_var_fn
 {
     template<class Context>
     [[nodiscard]] static constexpr auto&&
     operator()(Context const& ctx BOOST_SPIRIT_LIFETIMEBOUND) noexcept
     {
-        return x4::get<contexts::rule_val>(ctx);
+        return x4::get<contexts::rule_var>(ctx);
     }
 
     template<class Context>
@@ -106,9 +103,14 @@ struct _attr_fn
 inline namespace cpos {
 
 [[maybe_unused]] inline constexpr detail::_pass_fn _pass{};
-[[maybe_unused]] inline constexpr detail::_val_fn _val{};
+
+[[maybe_unused]] inline constexpr detail::_rule_var_fn _rule_var{};
+
+[[maybe_unused, deprecated("Use `_rule_var`")]]
+inline constexpr detail::_rule_var_fn _val{};
+
 [[maybe_unused]] inline constexpr detail::_as_var_fn _as_var{};
-[[maybe_unused]] inline constexpr detail::_where_fn _where{};
+[[maybe_unused]] inline constexpr detail::_where_fn _where{}; // obsolete
 [[maybe_unused]] inline constexpr detail::_attr_fn _attr{};
 
 } // cpos

--- a/include/boost/spirit/x4/directive/as.hpp
+++ b/include/boost/spirit/x4/directive/as.hpp
@@ -22,7 +22,7 @@ struct as_directive_ctx_impl // false
 template<class Context, X4Attribute Attr>
 struct as_directive_ctx_impl<true, Context, Attr>
 {
-    using type = std::remove_cvref_t<decltype(x4::replace_first_context<contexts::as_val>(
+    using type = std::remove_cvref_t<decltype(x4::replace_first_context<contexts::as_var>(
         std::declval<Context const&>(),
         std::declval<Attr&>()
     ))>;
@@ -47,7 +47,7 @@ struct as_directive : unary_parser<Subject, as_directive<T, Subject>>
     static constexpr bool has_action = false; // Explicitly re-enable attribute detection in `x4::rule`
 
 private:
-    static constexpr bool need_as_val = Subject::has_action;
+    static constexpr bool need_as_var = Subject::has_action;
 
 public:
     // `as<T>(as<T>(subject))` forwards the outer `T&` for `subject`
@@ -55,10 +55,10 @@ public:
         requires std::same_as<std::remove_const_t<OuterAttr>, T>
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, OuterAttr& outer_attr) const
-        noexcept(is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_val, Context, OuterAttr>::type, OuterAttr>)
+        noexcept(is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_var, Context, OuterAttr>::type, OuterAttr>)
     {
-        if constexpr (need_as_val) {
-            return this->subject.parse(first, last, x4::replace_first_context<contexts::as_val>(ctx, outer_attr), outer_attr);
+        if constexpr (need_as_var) {
+            return this->subject.parse(first, last, x4::replace_first_context<contexts::as_var>(ctx, outer_attr), outer_attr);
         } else {
             return this->subject.parse(first, last, ctx, outer_attr);
         }
@@ -70,10 +70,10 @@ public:
             (!std::same_as<std::remove_const_t<OuterAttr>, T>)
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, OuterAttr&) const
-        noexcept(is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_val, Context, unused_type>::type, unused_type>)
+        noexcept(is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_var, Context, unused_type>::type, unused_type>)
     {
-        if constexpr (need_as_val) {
-            return this->subject.parse(first, last, x4::replace_first_context<contexts::as_val>(ctx, unused), unused);
+        if constexpr (need_as_var) {
+            return this->subject.parse(first, last, x4::replace_first_context<contexts::as_var>(ctx, unused), unused);
         } else {
             return this->subject.parse(first, last, ctx, unused);
         }
@@ -87,7 +87,7 @@ public:
     [[nodiscard]] constexpr bool
     parse(It& first, Se const& last, Context const& ctx, OuterAttr& outer_attr) const
         noexcept(
-            is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_val, Context, T>::type, T> &&
+            is_nothrow_parsable_v<Subject, It, Se, typename detail::as_directive_ctx_impl<need_as_var, Context, T>::type, T> &&
             noexcept(x4::move_to(std::declval<T>(), outer_attr))
         )
     {
@@ -101,8 +101,8 @@ public:
 
         T attr_{}; // value-initialize
 
-        if constexpr (need_as_val) {
-            if (!this->subject.parse(first, last, x4::replace_first_context<contexts::as_val>(ctx, attr_), attr_)) return false;
+        if constexpr (need_as_var) {
+            if (!this->subject.parse(first, last, x4::replace_first_context<contexts::as_var>(ctx, attr_), attr_)) return false;
         } else {
             if (!this->subject.parse(first, last, ctx, attr_)) return false;
         }

--- a/test/x4/alternative.cpp
+++ b/test/x4/alternative.cpp
@@ -152,13 +152,13 @@ TEST_CASE("alternative")
 
         using x4::rule;
         using x4::_attr;
-        using x4::_val;
+        using x4::_rule_var;
 
         rule<class r1, wchar_t> r1;
         rule<class r2, wchar_t> r2;
         rule<class r3, wchar_t> r3;
 
-        constexpr auto f = [&](auto& ctx){ _val(ctx) = _attr(ctx); };
+        constexpr auto f = [&](auto& ctx){ _rule_var(ctx) = _attr(ctx); };
 
         (void)(r3 = (eps >> r1)[f]);
         (void)(r3 = (r1 | r2)[f]);

--- a/test/x4/as.cpp
+++ b/test/x4/as.cpp
@@ -34,7 +34,7 @@ TEST_CASE("as")
     using x4::eps;
     using x4::string;
     using x4::_attr;
-    using x4::_val;
+    using x4::_rule_var;
     using x4::_as_var;
 
     using It = std::string_view::const_iterator;
@@ -166,7 +166,7 @@ TEST_CASE("as")
         constexpr auto string_rule = x4::rule<struct _, decltype(result)>{""} =
             x4::as<std::string>(
                 eps[([](auto&& ctx) {
-                    _val(ctx) = "default";
+                    _rule_var(ctx) = "default";
                 })] >>
 
                 eps[([](auto&& ctx) {
@@ -188,7 +188,7 @@ TEST_CASE("as")
         constexpr auto string_rule = x4::rule<struct _, decltype(result)>{""} =
             x4::as<std::string>(
                 eps[([](auto&& ctx) {
-                    _val(ctx) = "default";
+                    _rule_var(ctx) = "default";
                 })] >>
 
                 eps[([]([[maybe_unused]] auto&& ctx) {
@@ -248,7 +248,7 @@ TEST_CASE("as")
         CHECK(result == "default"sv);
     }
 
-    // Use `_val(ctx)` inside `as<T>(...)`
+    // Use `_rule_var(ctx)` inside `as<T>(...)`
     {
         struct StringLiteral
         {
@@ -259,15 +259,15 @@ TEST_CASE("as")
         StringLiteral result;
 
         constexpr auto string_literal = x4::rule<struct _, StringLiteral>{"StringLiteral"} =
-            eps[([](auto& ctx) { _val(ctx).is_quoted = false; })] >>
+            eps[([](auto& ctx) { _rule_var(ctx).is_quoted = false; })] >>
             x4::as<std::string>(
                 x4::lit('"')[([](auto&& ctx) {
-                    StringLiteral& rule_val = _val(ctx);
-                    rule_val.is_quoted = true;
+                    StringLiteral& rule_var = _rule_var(ctx);
+                    rule_var.is_quoted = true;
                 })] >>
                 *~x4::char_('"') >>
                 '"'
-            )[([](auto&& ctx) { _val(ctx).text = std::move(_attr(ctx)); })];
+            )[([](auto&& ctx) { _rule_var(ctx).text = std::move(_attr(ctx)); })];
 
         std::string_view input = R"("foo")";
         It first = input.begin();

--- a/test/x4/as.cpp
+++ b/test/x4/as.cpp
@@ -35,7 +35,7 @@ TEST_CASE("as")
     using x4::string;
     using x4::_attr;
     using x4::_val;
-    using x4::_as_val;
+    using x4::_as_var;
 
     using It = std::string_view::const_iterator;
     using Se = It;
@@ -159,7 +159,7 @@ TEST_CASE("as")
         }
     }
 
-    // `as_val(ctx)` (with auto attribute propagation)
+    // `_as_var(ctx)` (with auto attribute propagation)
     {
         std::string result;
 
@@ -170,7 +170,7 @@ TEST_CASE("as")
                 })] >>
 
                 eps[([](auto&& ctx) {
-                    _as_val(ctx) = "foo";
+                    _as_var(ctx) = "foo";
                 })]
             );
 
@@ -181,7 +181,7 @@ TEST_CASE("as")
         REQUIRE(string_rule.parse(first, last, unused, result));
         CHECK(result == "foo"sv);
     }
-    // `as_val(ctx)` (with disabled attribute)
+    // `_as_var(ctx)` (with disabled attribute)
     {
         std::string result;
 
@@ -192,7 +192,7 @@ TEST_CASE("as")
                 })] >>
 
                 eps[([]([[maybe_unused]] auto&& ctx) {
-                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
+                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_var(ctx))>, unused_type>);
                 })]
             ) >> disable_attr; // <----------
 
@@ -203,14 +203,14 @@ TEST_CASE("as")
         REQUIRE(string_rule.parse(first, last, unused, result));
         CHECK(result == "default"sv);
     }
-    // `as_val(ctx)` (within `as<unused_type>(as<std::string>(...))`)
+    // `_as_var(ctx)` (within `as<unused_type>(as<std::string>(...))`)
     {
         std::string result{"default"};
 
         constexpr auto unused_rule = x4::as<unused_type>(
             x4::as<std::string>(
                 eps[([]([[maybe_unused]] auto&& ctx) {
-                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
+                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_var(ctx))>, unused_type>);
                 })]
             )
         );
@@ -222,7 +222,7 @@ TEST_CASE("as")
         REQUIRE(unused_rule.parse(first, last, unused, result));
         CHECK(result == "default"sv);
     }
-    // `as_val(ctx)` (within `as<std::string>(as<unused_type>(...))`)
+    // `_as_var(ctx)` (within `as<std::string>(as<unused_type>(...))`)
     {
         std::string result;
 
@@ -230,12 +230,12 @@ TEST_CASE("as")
             x4::attr("default") >>
 
             eps[([]([[maybe_unused]] auto&& ctx) {
-                static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, std::string>);
+                static_assert(std::same_as<std::remove_cvref_t<decltype(_as_var(ctx))>, std::string>);
             })] >>
 
             x4::as<unused_type>(
                 eps[([]([[maybe_unused]] auto&& ctx) {
-                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_val(ctx))>, unused_type>);
+                    static_assert(std::same_as<std::remove_cvref_t<decltype(_as_var(ctx))>, unused_type>);
                 })]
             )
         );

--- a/test/x4/rule3.cpp
+++ b/test/x4/rule3.cpp
@@ -96,7 +96,7 @@ TEST_CASE("rule3")
     using x4::rule;
     using x4::lit;
     using x4::eps;
-    using x4::_val;
+    using x4::_rule_var;
     using x4::_attr;
 
     // synth attribute value-init
@@ -105,7 +105,7 @@ TEST_CASE("rule3")
         using rule_type = rule<class r, std::string>;
 
         auto rdef = rule_type{} = alpha[([](auto&& ctx) {
-            x4::_val(ctx) += x4::_attr(ctx);
+            x4::_rule_var(ctx) += x4::_attr(ctx);
         })];
 
         REQUIRE(parse("abcdef", +rdef, s));
@@ -119,7 +119,7 @@ TEST_CASE("rule3")
 
         auto rdef = rule_type() =
             alpha[([](auto&& ctx) {
-                _val(ctx) += _attr(ctx);
+                _rule_var(ctx) += _attr(ctx);
             })];
 
         REQUIRE(parse("abcdef", +rdef, s));
@@ -129,7 +129,7 @@ TEST_CASE("rule3")
     {
         auto r = rule<class r_id, int>{} = eps[([] ([[maybe_unused]] auto&& ctx) {
             static_assert(
-                std::is_same_v<std::decay_t<decltype(_val(ctx))>, unused_type>,
+                std::is_same_v<std::decay_t<decltype(_rule_var(ctx))>, unused_type>,
                 "Attr must not be synthesized"
             );
         })];

--- a/test/x4/rule_separate_tu.cpp
+++ b/test/x4/rule_separate_tu.cpp
@@ -69,7 +69,7 @@ TEST_CASE("rule_separate_tu")
             x4::contexts::expectation_failure,
             x4::expectation_failure<std::string_view::const_iterator>,
             x4::context<
-                x4::contexts::rule_val,
+                x4::contexts::rule_var,
                 int
             >
         >;
@@ -80,7 +80,7 @@ TEST_CASE("rule_separate_tu")
 
         static_assert(std::same_as<
             std::remove_cvref_t<decltype(
-                x4::remove_first_context<x4::contexts::rule_val>(std::declval<Context const&>())
+                x4::remove_first_context<x4::contexts::rule_var>(std::declval<Context const&>())
             )>,
             RuleAgnosticContext
         >);

--- a/test/x4/with.cpp
+++ b/test/x4/with.cpp
@@ -31,14 +31,14 @@ struct match_counter_rule_id
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Failure, class Context>
     void on_error(It const&, Se const&, Context const& ctx, Failure const&)
     {
-        STATIC_CHECK(x4::has_context_of_v<Context, x4::contexts::rule_val, ExpectedAttr>);
+        STATIC_CHECK(x4::has_context_of_v<Context, x4::contexts::rule_var, ExpectedAttr>);
         ++x4::get<my_tag>(ctx);
     }
 
     template<std::forward_iterator It, std::sentinel_for<It> Se, class Context, x4::X4Attribute Attr>
     void on_success(It const&, Se const&, Context const& ctx, Attr&)
     {
-        STATIC_CHECK(x4::has_context_of_v<Context, x4::contexts::rule_val, ExpectedAttr>);
+        STATIC_CHECK(x4::has_context_of_v<Context, x4::contexts::rule_var, ExpectedAttr>);
         ++x4::get<my_tag>(ctx);
     }
 };
@@ -161,7 +161,7 @@ TEST_CASE("with")
         })];
         auto const r2 = rule<struct my_rvalue_rule_class, int>() =
             x4::lit('(') >> (r1 % ',') >> x4::lit(')')[([](auto&& ctx){
-                x4::_val(ctx) = x4::get<my_tag>(ctx);
+                x4::_rule_var(ctx) = x4::get<my_tag>(ctx);
             })];
         int attr = 0;
         REQUIRE(parse("(1,2,3)", with<my_tag>(100)[r2], attr));
@@ -183,7 +183,7 @@ TEST_CASE("with")
         };
 
         auto f = [](auto&& ctx){
-            x4::_val(ctx) = x4::_attr(ctx) + functor()(x4::get<my_tag>(ctx));
+            x4::_rule_var(ctx) = x4::_attr(ctx) + functor()(x4::get<my_tag>(ctx));
         };
         auto const r = rule<struct my_rule_class2, int>() = int_[f];
 

--- a/test/x4/with_local.cpp
+++ b/test/x4/with_local.cpp
@@ -25,7 +25,7 @@ TEST_CASE("with_local")
     using x4::as;
     using x4::_local_var;
     using x4::_attr;
-    using x4::_as_val;
+    using x4::_as_var;
     using x4::int_;
     using x4::eps;
 
@@ -38,7 +38,7 @@ TEST_CASE("with_local")
                     _local_var(ctx) = _attr(ctx) * 100;
                 })] >>
                 eps[([](auto&& ctx) {
-                    _as_val(ctx) = _local_var(ctx);
+                    _as_var(ctx) = _local_var(ctx);
                 })]
             )
         ];


### PR DESCRIPTION
Part of #1 
Follow-up for #73 

This PR syncs the naming scheme for action contexts. The new naming originated from the introduction of `_local_var` in #73, where the name "local var" is carefully chosen to reflect the fact that it points to "local variable", not "local value".

The same should apply to all other existing contexts.

#### Before:
- `_val`
- `_as_val`
- `_local_var`

#### After:
- `_rule_var`
  - `_val` (with `[[deprecated]]`) still provided for backward compatibility.
- `_as_var`
- `_local_var`
